### PR TITLE
Add gclone function to zsh configuration

### DIFF
--- a/nix/modules/zsh.nix
+++ b/nix/modules/zsh.nix
@@ -83,6 +83,11 @@ in
 
       # Initialize zoxide only in interactive shells
       [[ $- == *i* ]] && eval "$(${pkgs.zoxide}/bin/zoxide init zsh --cmd cd)"
+
+      # Custom functions
+      gclone() {
+        git clone "$1" && cd "$(basename "$1" .git)"
+      }
     '';
 
     shellAliases = {


### PR DESCRIPTION
## Summary
- Adds a `gclone` shell function that clones a git repository and automatically changes directory into the cloned folder
- Function handles repository URL parsing to extract the directory name correctly