### PR TITLE
feat: add cursor as git editor and pnpm_9 package

### DIFF
--- a/nix/modules/git.nix
+++ b/nix/modules/git.nix
@@ -47,6 +47,7 @@ in
       };
       init.defaultBranch = "main";
       tag.gpgsign = true;
+      core.editor = "cursor --wait";
     };
 
     includes = [{

--- a/nix/modules/packages.nix
+++ b/nix/modules/packages.nix
@@ -25,6 +25,7 @@
     openssl
     pipx
     pnpm
+    pnpm_9
     python3
     readline
     rsync


### PR DESCRIPTION
## Summary
- Configure `core.editor` to use `cursor --wait` for git operations  
- Add `pnpm_9` to available packages for development workflows

## Test plan
- [x] Applied configuration with `nixup`  
- [x] Verified git editor configuration is active
- [x] System rebuild completed successfully