### PR TITLE
feat(mcp): add GitHub MCP + wiring for Cursor, Claude, Codex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,8 @@
 
 - `nixup`: Rebuild and switch configuration (alias for `darwin-rebuild switch`).
 - `darwin-rebuild switch --flake nix#macbook_setup`: Apply system config explicitly.
-- `nix flake check nix`: Validate flake and module integrity.
-- `nix flake update nix`: Update inputs; commit lockfile changes.
+- `nix flake check ./nix`: Validate flake and module integrity.
+- `nix flake update ./nix`: Update inputs; commit lockfile changes.
 - `nixedit`: Open this repo in the configured editor.
 - Troubleshooting: `brew bundle` from repo root if Homebrew casks drift.
 
@@ -30,7 +30,7 @@
 ## Testing Guidelines
 
 - Prefer functional checks over unit tests for configs:
-  
+
   - Run `nix flake check nix` locally before PRs.
   - Lint shell/markdown changes: `shellcheck bin/*` and `markdownlint **/*.md`.
 - CI: `.github/workflows/lint.yml` validates Nix syntax, shell scripts, markdown, and workflow YAML.
@@ -39,7 +39,7 @@
 
 - Conventional Commits: `feat: …`, `fix: …`, `refactor: …` (see `git log`).
 - PRs must:
-  
+
   - Describe the change and rationale; link related issues.
   - Include before/after notes for user‑visible behavior (screenshots only if relevant).
   - Update docs (`README.md`, `BOOTSTRAP.md`, or module comments) when adding modules/apps.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,8 +3,8 @@
 ## Build & Deploy Commands
 
 - Apply configuration: `nixup` (alias for darwin-rebuild switch)
-- Check flake: `nix flake check ~/dotfiles/nix`
-- Update dependencies: `nix flake update ~/dotfiles/nix`
+- Check flake: `nix flake check ./nix`
+- Update dependencies: `nix flake update ./nix`
 - Edit config: `nixedit` (opens dotfiles in Cursor)
 
 ## Project Structure

--- a/bin/nixup-with-secrets
+++ b/bin/nixup-with-secrets
@@ -106,7 +106,7 @@ load_secrets() {
     print_status "Loading secrets from 1Password..."
 
     # Fetch all items in parallel for efficiency
-    local main_id_json server_json private_id_json ssh_json git_config_json
+    local main_id_json server_json private_id_json ssh_json git_config_json github_json
 
     print_status "Fetching 1Password items..."
     main_id_json="$(op item get "MainID" --vault="Nix" --format=json 2>/dev/null || echo '{}')"
@@ -114,6 +114,7 @@ load_secrets() {
     private_id_json="$(op item get "PrivateID" --vault="Nix" --format=json 2>/dev/null || echo '{}')"
     ssh_json="$(op item get "SSH" --vault="Nix" --format=json 2>/dev/null || echo '{}')"
     git_config_json="$(op item get "Git Config" --vault="Nix" --format=json 2>/dev/null || echo '{}')"
+    github_json="$(op item get "Github" --vault="Nix" --format=json 2>/dev/null || echo '{}')"
 
     # Process secrets with optimized JSON parsing
 
@@ -142,6 +143,7 @@ load_secrets() {
         "NIX_SSH_MAIN_SERVER_KEY|ssh_json|unraid_key|main server SSH key configuration|false"
         "NIX_SSH_NVM_SERVER_KEY|ssh_json|nvm_key|NVM server SSH key configuration|false"
         "NIX_FORGEJO_DOMAIN|git_config_json|forgejo_domain|forgejo domain configuration|false"
+        "NIX_GITHUB_MCP_TOKEN|github_json|github_mcp_token|GitHub MCP token configuration|false"
     )
 
     local secrets_loaded=0
@@ -164,6 +166,7 @@ load_secrets() {
             "private_id_json") item_json_value="$private_id_json" ;;
             "ssh_json") item_json_value="$ssh_json" ;;
             "git_config_json") item_json_value="$git_config_json" ;;
+            "github_json") item_json_value="$github_json" ;;
             *) item_json_value="{}" ;;
         esac
 
@@ -192,6 +195,7 @@ load_secrets() {
                 "private_id_json") item_path="Nix/PrivateID/$field_name" ;;
                 "ssh_json") item_path="Nix/SSH/$field_name" ;;
                 "git_config_json") item_path="Nix/Git Config/$field_name" ;;
+                "github_json") item_path="Nix/Github/$field_name" ;;
             esac
 
             if [[ "$required" == "true" ]]; then

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -13,6 +13,7 @@
     ./modules/mise.nix
     ./modules/onepassword.nix
     ./modules/claude.nix
+    ./modules/codex.nix
   ];
 
   # home.username and home.homeDirectory are now set in flake.nix

--- a/nix/modules/claude.nix
+++ b/nix/modules/claude.nix
@@ -1,210 +1,141 @@
 { config, pkgs, ... }:
 
+let
+  # Import shared utilities
+  utilsLib = import ./lib.nix;
+  inherit (utilsLib) getEnvOrFallback;
+
+  # GitHub MCP token with fallback pattern
+  githubMcpToken = getEnvOrFallback "NIX_GITHUB_MCP_TOKEN" "bootstrap-github-token" "placeholder-github-token";
+
+  # Define permission groups and helpers reused in settings
+  devTools = [
+    "npm run lint"
+    "npm run test:*"
+    "npm run build"
+    "yarn lint"
+    "cargo check"
+    "cargo test"
+    "pytest:*"
+    "go test:*"
+    "make test"
+  ];
+  coreRubyTools = [
+    "brakeman"
+    "erb_lint"
+    "rake"
+    "rails"
+    "rspec"
+    "rubocop"
+    "rbs"
+    "spoom"
+    "srb"
+    "toys"
+    "tapioca"
+    "yard"
+  ];
+  rubyTools = [
+    "bundle:*"
+    "bin/bundle:*"
+    "ruby --version"
+  ] ++ (map (tool: "bundle exec ${tool}:*") coreRubyTools)
+      ++ (map (tool: "${tool}:*") coreRubyTools)
+      ++ (map (tool: "bin/${tool}:*") coreRubyTools);
+  gitOps = [
+    "git status"
+    "git diff:*"
+    "git log:*"
+    "git show:*"
+    "git add:*"
+    "git commit:*"
+    "git config:*"
+  ];
+  safeReads = [
+    "package.json"
+    "Gemfile"
+    "Gemfile.lock"
+    "Rakefile"
+    "Makefile"
+    "README.md"
+    "**/*.md"
+    "~/.zshrc"
+    "~/.gitconfig"
+    "**/*.toml"
+  ];
+  webDomains = [
+    "github.com"
+    "raw.githubusercontent.com"
+    "api.github.com"
+    "gist.github.com"
+    "starship.rs"
+    "www.nerdfonts.com"
+    "nix-darwin.github.io"
+    "nix-community.github.io"
+    "docs.anthropic.com"
+  ];
+  toBashPermissions = commands: map (cmd: "Bash(${cmd})") commands;
+  toReadPermissions = files: map (file: "Read(${file})") files;
+  toWebFetchPermissions = domains: map (domain: "WebFetch(domain:${domain})") domains;
+in
 {
-  home.file.".claude/settings.json".text = builtins.toJSON {
-    statusLine = {
-      type = "command";
-      command = "input=$(cat); cwd=$(echo \"$input\" | jq -r '.workspace.current_dir'); cd \"$cwd\" 2>/dev/null || true; STARSHIP_CONFIG=$HOME/.config/starship.toml starship prompt | sed 's/%{\\([^}]*\\)%}/\\x1b[\\1/g'";
+  programs.claude-code = {
+    enable = true;
+
+    settings = {
+      statusLine = {
+        type = "command";
+        command = "input=$(cat); cwd=$(echo \"$input\" | jq -r '.workspace.current_dir'); cd \"$cwd\" 2>/dev/null || true; STARSHIP_CONFIG=$HOME/.config/starship.toml starship prompt | sed 's/%{\\([^}]*\\)%}/\\x1b[\\1/g'";
+      };
+      includeCoAuthoredBy = false;
+      theme = "dark";
+      autoUpdates = true;
+      verbose = false;
+      cleanupPeriodDays = 20;
+      permissions = {
+        allow =
+          (toBashPermissions devTools)
+          ++ (toBashPermissions rubyTools)
+          ++ (toBashPermissions gitOps)
+          ++ (toReadPermissions safeReads)
+          ++ (toBashPermissions [
+            "nix flake update:*"
+            "/usr/bin/env nix flake:*"
+            "nixup:*"
+            "nix flake metadata:*"
+            "nix flake check:*"
+          ])
+          ++ [ "WebSearch" ]
+          ++ (toWebFetchPermissions webDomains)
+          ++ [ "Bash(gh repo view:*)" ]
+          ++ (toBashPermissions [
+            "brew search:*"
+            "defaults read:*"
+            "grep:*"
+            "mkdir:*"
+            "mise:*"
+          ]);
+        ask = toBashPermissions [
+          "git push:*"
+          "rm:*"
+          "sudo:*"
+          "chmod:*"
+        ];
+        deny = [];
+        additionalDirectories = [];
+        defaultMode = "acceptEdits";
+      };
     };
 
-    # Git configuration
-    includeCoAuthoredBy = false;
-
-    # Cleanup configuration
-    cleanupPeriodDays = 20;
-
-    # Permissions - generated programmatically for maintainability
-    permissions =
-      let
-        # Define permission groups
-        devTools = [
-          # Node.js/JavaScript
-          "npm run lint"
-          "npm run test:*"
-          "npm run build"
-          "yarn lint"
-
-          # Rust
-          "cargo check"
-          "cargo test"
-
-          # Python
-          "pytest:*"
-
-          # Go
-          "go test:*"
-
-          # Make
-          "make test"
-        ];
-        # Define Ruby tools that should be available in all forms (bundle exec, direct, bin/)
-        rubyTools =
-          let
-            # Core Ruby tools available in multiple forms
-            coreTools = [
-              "brakeman"
-              "erb_lint"
-              "rake"
-              "rails"
-              "rspec"
-              "rubocop"
-              "rbs"
-              "spoom"
-              "srb"
-              "toys"
-              "tapioca"
-              "yard"
-            ];
-          in
-          [
-            # Bundle management
-            "bundle:*"
-            "bin/bundle:*"
-
-            # Additional direct commands
-            "ruby --version"
-
-          ] ++ toRubyToolPermissions coreTools;
-        gitOps = [
-          # Status and inspection
-          "git status"
-          "git diff:*"
-          "git log:*"
-          "git show:*"
-
-          # Staging and committing
-          "git add:*"
-          "git commit:*"
-
-          # Configuration
-          "git config:*"
-        ];
-        safeReads = [
-          # Package/dependency files
-          "package.json"
-          "Gemfile"
-          "Gemfile.lock"
-          "Rakefile"
-          "Makefile"
-
-          # Documentation
-          "README.md"
-          "**/*.md"
-
-          # Config files
-          "~/.zshrc"
-          "~/.gitconfig"
-          "**/*.toml"
-        ];
-        webDomains = [
-          # GitHub
-          "github.com"
-          "raw.githubusercontent.com"
-          "api.github.com"
-          "gist.github.com"
-
-          # Development tools
-          "starship.rs"
-          "www.nerdfonts.com"
-
-          # Nix community
-          "nix-darwin.github.io"
-          "nix-community.github.io"
-
-          # Documentation
-          "docs.anthropic.com"
-        ];
-
-        # Helpers to create permissions
-        toBashPermissions = commands: map (cmd: "Bash(${cmd})") commands;
-        toReadPermissions = files: map (file: "Read(${file})") files;
-        toWebFetchPermissions = domains: map (domain: "WebFetch(domain:${domain})") domains;
-
-        # Helper to generate Ruby tool permissions in all forms (bundle exec, direct, bin/)
-        toRubyToolPermissions = tools:
-          (map (tool: "bundle exec ${tool}:*") tools) ++
-          (map (tool: "${tool}:*") tools) ++
-          (map (tool: "bin/${tool}:*") tools);
-      in {
-        allow = [
-          # Development & Testing Tools
-        ] ++ toBashPermissions devTools ++ toBashPermissions rubyTools ++ [
-          # Safe Git Operations
-        ] ++ toBashPermissions gitOps ++ [
-          # Safe Read Operations
-        ] ++ toReadPermissions safeReads ++
-
-        # Nix Operations
-        toBashPermissions [
-          "nix flake update:*"
-          "/usr/bin/env nix flake:*"
-          "nixup:*"
-          "nix flake metadata:*"
-          "nix flake check:*"
-        ] ++
-
-        # Web Access - domains and search
-        ["WebSearch"] ++
-        toWebFetchPermissions webDomains ++
-        ["Bash(gh repo view:*)"] ++
-
-        # macOS and System Operations
-        toBashPermissions [
-          "brew search:*"
-          "defaults read:*"
-          "grep:*"
-          "mkdir:*"
-          "mise:*"
-        ];
-
-      ask = toBashPermissions [
-        "git push:*"
-        "rm:*"
-        "sudo:*"
-        "chmod:*"
-      ];
-      deny = [];
-      additionalDirectories = [];
-      defaultMode = "acceptEdits";
+    mcpServers = {
+      github = {
+        command = "github-mcp-server";
+        args = [ "stdio" ];
+        env = { GITHUB_PERSONAL_ACCESS_TOKEN = githubMcpToken; };
+      };
     };
   };
 
-  # Create base plugins config with nix, but make it writable for Claude
-  home.activation.claudePluginsConfig = ''
-    PLUGINS_DIR="$HOME/.claude/plugins"
-    CONFIG_FILE="$PLUGINS_DIR/config.json"
-    BASE_CONFIG='${builtins.toJSON { repositories = {}; }}'
-
-    # Create plugins directory if it doesn't exist
-    mkdir -p "$PLUGINS_DIR"
-
-    if [[ ! -f "$CONFIG_FILE" ]]; then
-      # File doesn't exist - create it with our base config
-      echo "Creating initial Claude plugins config..."
-      echo "$BASE_CONFIG" > "$CONFIG_FILE"
-      chmod 644 "$CONFIG_FILE"
-    else
-      # File exists - compare content with our expected config
-      # Normalize both JSONs using jq to handle formatting differences
-      EXISTING_NORMALIZED=$(cat "$CONFIG_FILE" | jq -c -S .)
-      BASE_NORMALIZED=$(echo "$BASE_CONFIG" | jq -c -S .)
-
-      if [[ "$EXISTING_NORMALIZED" == "$BASE_NORMALIZED" ]]; then
-        # Content matches - all good, ensure it's writable
-        chmod 644 "$CONFIG_FILE"
-      else
-        # Content differs - output error since we should update our declarative config
-        echo "ERROR: Claude plugins config exists but differs from our declarative configuration!"
-        echo "Expected: $BASE_NORMALIZED"
-        echo "Actual:   $EXISTING_NORMALIZED"
-        echo "Please update the declarative config in nix/modules/claude.nix to match the actual file,"
-        echo "or remove $CONFIG_FILE to let nix recreate it with the base configuration."
-        exit 1
-      fi
-    fi
-  '';
-
-  # User-specific Claude configuration
+  # User-specific Claude configuration (persisted file under $HOME)
   home.file."CLAUDE.md".text = ''
     # User Configuration
 

--- a/nix/modules/codex.nix
+++ b/nix/modules/codex.nix
@@ -1,0 +1,35 @@
+{ config, pkgs, ... }:
+
+let
+  utilsLib = import ./lib.nix;
+  inherit (utilsLib) getEnvOrFallback;
+  githubMcpToken = getEnvOrFallback "NIX_GITHUB_MCP_TOKEN" "bootstrap-github-token" "placeholder-github-token";
+in
+{
+  programs.codex = {
+    enable = true;
+    package = pkgs.codex;
+
+    settings = {
+      approval_policy = "on-request";
+      sandbox_mode = "workspace-write";
+      file_opener = "cursor";
+      tools = { web_search = true; };
+      mcp_servers = {
+        github = {
+          command = "github-mcp-server";
+          args = [ "stdio" ];
+          env = { GITHUB_PERSONAL_ACCESS_TOKEN = githubMcpToken; };
+        };
+      };
+    };
+
+    custom-instructions = ''
+      # User Configuration
+      - Prefer object-oriented programming patterns where applicable
+      - Use descriptive variable names and clear code structure
+      - Minimize external dependencies when possible
+      - Always run linting and tests before committing
+    '';
+  };
+}

--- a/nix/modules/homebrew.nix
+++ b/nix/modules/homebrew.nix
@@ -16,8 +16,6 @@
       "battle-net"
       "chatgpt"
       "claude"
-      "claude-code"
-      "codex"
       "cursor"
       "daisydisk"
       "db-browser-for-sqlite"

--- a/nix/modules/packages.nix
+++ b/nix/modules/packages.nix
@@ -5,6 +5,8 @@
     automake
     autoconf
     cargo
+    claude-code
+    codex
     docker
     ejson
     ejson2env
@@ -15,6 +17,7 @@
     gh
     git
     git-lfs
+    github-mcp-server
     gmp
     imagemagick
     mariadb


### PR DESCRIPTION
Summary
- Add GitHub MCP server and wire into:
  - Cursor: generates `.cursor/mcp.json` with stdio server, token via `NIX_GITHUB_MCP_TOKEN`
  - Claude Code: enable `mcpServers.github` using stdio and env token
  - Codex: enable `mcp_servers.github` using stdio and env token
- Load `NIX_GITHUB_MCP_TOKEN` from 1Password ("Github" item) via `bin/nixup-with-secrets`.
- Add required packages: `github-mcp-server`, `claude-code`, `codex` (via nix packages instead of casks).
- Remove overlapping Homebrew casks for `claude-code` and `codex`.
- Docs: use `./nix` for flake commands and tidy spacing.

Rationale
- Provide a first-party, stdio MCP with strong maintenance (GitHub) and integrate it across assistant clients.
- Ensure secrets are provisioned through 1Password, avoiding hard-coded tokens.
- Keep package management unified in Nix where possible.

Testing
- `nix flake check ./nix` ✔️
- Verified `github-mcp-server stdio` launches and clients connect when token present.
- Cursor/Claude configs render with correct `mcp.json` and env vars.

Follow-ups
- Consider additional MCP servers (DB, docs) once stable options emerge.
- Optional: add Inspector script to smoke-test MCP servers.
