### PR TITLE
feat(mcp): integrate rails-mcp-server via nixup; add bin helpers

### DIFF
--- a/bin/rails-mcp-add-project
+++ b/bin/rails-mcp-add-project
@@ -1,0 +1,128 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/shared"
+
+show_help() {
+  cat <<'EOF'
+Usage: rails-mcp-add-project [--auto] [--name NAME --path PATH [--env ENV]]
+
+Adds or updates a project entry in ~/.config/rails-mcp/projects.yml.
+
+Modes:
+  --auto (or no args):
+    - Detect current git repo root as PATH
+    - Infer NAME from directory basename
+    - Verify Rails app heuristics (bin/rails or config/application.rb + Gemfile)
+    - ENV defaults to development (or RAILS_ENV if set)
+
+  Manual:
+    --name NAME --path PATH [--env ENV]
+    - Defaults: --env development
+EOF
+}
+
+name=""
+path=""
+env="development"
+auto="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --auto) auto="true"; shift ;;
+    -n|--name) name="${2:-}"; shift 2;;
+    -p|--path) path="${2:-}"; shift 2;;
+    -e|--env) env="${2:-}"; shift 2;;
+    -h|--help) show_help; exit 0;;
+    *) print_error "Unknown argument: $1"; show_help; exit 1;;
+  esac
+done
+
+if [[ "$auto" == "true" || ( -z "$name" && -z "$path" ) ]]; then
+  # Auto-detect mode
+  if ! git_root=$(git rev-parse --show-toplevel 2>/dev/null); then
+    print_error "Not inside a git repository; cannot auto-detect"
+    exit 1
+  fi
+  path="$git_root"
+  name="$(basename "$git_root")"
+  env="${RAILS_ENV:-$env}"
+
+  if [[ -x "$git_root/bin/rails" ]]; then
+    print_status "Detected Rails project via bin/rails"
+  elif [[ -f "$git_root/config/application.rb" && -f "$git_root/Gemfile" && $(grep -iE "^\s*gem\s+['\"]rails['\"]" "$git_root/Gemfile" || true) ]]; then
+    print_status "Detected Rails project via config/application.rb and Gemfile"
+  else
+    print_error "Current repo doesn't look like a Rails app (no bin/rails or rails gem)"
+    exit 1
+  fi
+else
+  # Manual mode requires name and path
+  if [[ -z "$name" || -z "$path" ]]; then
+    print_error "--name and --path are required in manual mode"
+    show_help
+    exit 1
+  fi
+fi
+
+config_dir="$HOME/.config/rails-mcp"
+projects_file="$config_dir/projects.yml"
+mkdir -p "$config_dir"
+
+if [[ ! -f "$projects_file" ]]; then
+  print_status "Initializing $projects_file"
+  cat > "$projects_file" <<'YAML'
+projects: []
+YAML
+fi
+
+print_status "Adding project '$name' at '$path' (env=$env)"
+
+if ! command -v mise >/dev/null 2>&1; then
+  print_error "mise is not installed; ensure nixup completed successfully"
+  exit 1
+fi
+
+# Use Ruby (via mise) to safely modify YAML preserving structure
+PROJECTS_FILE="$projects_file" PROJ_NAME="$name" PROJ_PATH="$path" PROJ_ENV="$env" \
+  mise x ruby -- ruby - <<'RUBY'
+require 'yaml'
+file = ENV['PROJECTS_FILE']
+name = ENV['PROJ_NAME']
+path = ENV['PROJ_PATH']
+env  = ENV['PROJ_ENV']
+
+loaded = nil
+if File.exist?(file)
+  begin
+    loaded = YAML.load_file(file)
+  rescue StandardError
+    loaded = nil
+  end
+end
+
+data = loaded.is_a?(Hash) ? loaded : { 'projects' => [] }
+projects = data['projects']
+projects = [] unless projects.is_a?(Array)
+projects = projects.compact.select { |p| p.is_a?(Hash) }
+
+existing_index = projects.index { |p| p['path'] == path || p['name'] == name }
+if existing_index
+  projects[existing_index]['name'] = name
+  projects[existing_index]['path'] = path
+  projects[existing_index]['env']  = env
+  data['projects'] = projects
+  File.write(file, YAML.dump(data))
+  puts "Updated project: #{name} (#{path})"
+else
+  projects << { 'name' => name, 'path' => path, 'env' => env }
+  data['projects'] = projects
+  File.write(file, YAML.dump(data))
+  puts "Added project: #{name} (#{path})"
+end
+RUBY
+
+print_success "Done"
+
+

--- a/bin/rails-mcp-server
+++ b/bin/rails-mcp-server
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/shared"
+
+print_status "Launching rails-mcp-server via mise (Ruby from ~/.ruby-version or latest)"
+
+if ! command -v mise >/dev/null 2>&1; then
+  print_error "mise is not installed; ensure nixup completed successfully"
+  exit 1
+fi
+
+exec mise x ruby -- rails-mcp-server "$@"
+
+

--- a/bin/rails-mcp-server-download-resources
+++ b/bin/rails-mcp-server-download-resources
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/shared"
+
+if [[ $# -eq 0 ]]; then
+  print_error "Usage: rails-mcp-server-download-resources <rails|turbo|stimulus|kamal|custom> [--file /path/to/docs]"
+  exit 1
+fi
+
+print_status "Downloading Rails MCP Server resources: $*"
+
+if ! command -v mise >/dev/null 2>&1; then
+  print_error "mise is not installed; ensure nixup completed successfully"
+  exit 1
+fi
+
+exec mise x ruby -- rails-mcp-server-download-resources "$@"
+
+

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -5,6 +5,7 @@
     ./modules/gh.nix
     ./modules/git.nix
     ./modules/ruby.nix
+    ./modules/rails-mcp.nix
     ./modules/ssh.nix
     ./modules/zsh.nix
     ./modules/starship.nix

--- a/nix/modules/claude.nix
+++ b/nix/modules/claude.nix
@@ -132,6 +132,11 @@ in
         args = [ "stdio" ];
         env = { GITHUB_PERSONAL_ACCESS_TOKEN = githubMcpToken; };
       };
+      rails = {
+        command = "rails-mcp-server";
+        args = [ "stdio" ];
+        env = { };
+      };
     };
   };
 

--- a/nix/modules/codex.nix
+++ b/nix/modules/codex.nix
@@ -21,6 +21,11 @@ in
           args = [ "stdio" ];
           env = { GITHUB_PERSONAL_ACCESS_TOKEN = githubMcpToken; };
         };
+        rails = {
+          command = "rails-mcp-server";
+          args = [ "stdio" ];
+          env = { };
+        };
       };
     };
 

--- a/nix/modules/cursor.nix
+++ b/nix/modules/cursor.nix
@@ -22,6 +22,12 @@ let
           args = [ "stdio" ];
           env = { "GITHUB_PERSONAL_ACCESS_TOKEN" = githubMcpToken; };
         };
+        rails = {
+          type = "stdio";
+          command = "rails-mcp-server";
+          args = [ "stdio" ];
+          env = {};
+        };
       };
     }}
     JSON

--- a/nix/modules/rails-mcp.nix
+++ b/nix/modules/rails-mcp.nix
@@ -1,0 +1,67 @@
+{ lib, pkgs, ... }:
+
+{
+  # Ensure rails-mcp-server gem is available and provide stable wrappers
+  home.activation.installRailsMcpServer = lib.hm.dag.entryAfter ["writeBoundary"] ''
+    set -euo pipefail
+
+    export PATH="${pkgs.mise}/bin:$PATH:/usr/bin:/bin:/opt/homebrew/bin:/usr/local/bin"
+
+    # Determine ruby version from ~/.ruby-version if present; otherwise use latest configured by mise
+    ruby_version="$(cat "$HOME/.ruby-version" 2>/dev/null || echo "latest")"
+
+    echo -e "\033[34mEnsuring rails-mcp-server gem is installed/updated (Ruby $ruby_version)...\033[0m"
+    if ! mise x ruby@"$ruby_version" -- gem list -i rails-mcp-server >/dev/null 2>&1; then
+      echo -e "\033[33mInstalling rails-mcp-server gem...\033[0m"
+      mise x ruby@"$ruby_version" -- gem install rails-mcp-server --no-document >/dev/null
+      echo -e "\033[32mrails-mcp-server gem installed\033[0m"
+    else
+      echo -e "\033[33mUpdating rails-mcp-server gem (if needed)...\033[0m"
+      mise x ruby@"$ruby_version" -- gem update rails-mcp-server --no-document >/dev/null || true
+      echo -e "\033[32mrails-mcp-server gem ensured up-to-date\033[0m"
+    fi
+  '';
+
+  # Ensure official guide resources are present and refreshed periodically
+  home.activation.updateRailsMcpResources = lib.hm.dag.entryAfter ["installRailsMcpServer"] ''
+    set -euo pipefail
+
+    export PATH="${pkgs.mise}/bin:$PATH:/usr/bin:/bin:/opt/homebrew/bin:/usr/local/bin"
+
+    # Refresh resource packs; tolerate network or server hiccups without failing the build
+    for pack in rails turbo stimulus kamal; do
+      echo -e "\033[34mEnsuring rails-mcp-server resources for '$pack'...\033[0m"
+      if ! mise x ruby -- rails-mcp-server-download-resources "$pack" >/dev/null 2>&1; then
+        echo -e "\033[33mWarning: failed to update resources for '$pack' (will continue)\033[0m"
+      else
+        echo -e "\033[32mResources ensured for '$pack'\033[0m"
+      fi
+    done
+  '';
+
+  # Ensure projects.yml exists with a helpful template
+  home.activation.ensureRailsMcpConfig = lib.hm.dag.entryAfter ["updateRailsMcpResources"] ''
+    set -euo pipefail
+
+    config_dir="$HOME/.config/rails-mcp"
+    projects_file="$config_dir/projects.yml"
+    mkdir -p "$config_dir"
+
+    if [ ! -f "$projects_file" ]; then
+      cat > "$projects_file" <<'YAML'
+# rails-mcp-server projects configuration
+# Add your Rails apps here. Example:
+#
+# projects:
+#   - name: myapp
+#     path: /Users/you/dev/myapp
+#     env: development
+#
+projects: []
+YAML
+      echo -e "\033[34mCreated rails MCP projects file at $projects_file\033[0m"
+    fi
+  '';
+}
+
+


### PR DESCRIPTION
This PR adds rails-mcp-server integration:\n- nix activation installs/updates gem\n- resources (rails/turbo/stimulus/kamal) auto-updated during nixup\n- bin helpers: rails-mcp-server, rails-mcp-server-download-resources, rails-mcp-add-project\n- Cursor/Claude/Codex configs wired to use rails-mcp-server\n\nTested locally with nixup; resources fetched; helper auto-detect works for Rails repos.