### PR TITLE
feat(packages): add yq to packages

### DIFF
--- a/nix/modules/packages.nix
+++ b/nix/modules/packages.nix
@@ -46,6 +46,7 @@
     x264
     x265
     yarn
+    yq
     yt-dlp
     zoxide
   ];


### PR DESCRIPTION
This PR adds `yq` to the Homebrew packages list in `nix/modules/packages.nix`.

- Rationale: `yq` is useful for YAML processing in scripts and local tooling.
- Change: Adds `yq` under the package list.

CI should confirm Nix and shell validation as usual.