### PR TITLE
feat(packages): add ruff to Nix packages

### DIFF
--- a/nix/modules/packages.nix
+++ b/nix/modules/packages.nix
@@ -32,6 +32,7 @@
     python3
     readline
     rsync
+    ruff
     rustc
     scc
     speedtest-cli


### PR DESCRIPTION
This PR adds `ruff` to `environment.systemPackages` via `nix/modules/packages.nix`.

- Adds `ruff` to the default packages
- Follows repo conventions (Conventional Commits, Nix style, CI checks)

After merge, I will run `gbclean` locally.

Checklist:
- [x] `nix flake check nix` (skip if CI runs this)
- [x] Conventional commit message
