### PR TITLE
feat(ide): VS Code module + shared IDE extensions; align settings

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -11,10 +11,12 @@
     ./modules/starship.nix
     ./modules/home-manager-system-defaults.nix
     ./modules/cursor.nix
+    ./modules/vscode.nix
     ./modules/mise.nix
     ./modules/onepassword.nix
     ./modules/claude.nix
     ./modules/codex.nix
+    ./modules/ide-extensions.nix
   ];
 
   # home.username and home.homeDirectory are now set in flake.nix

--- a/nix/modules/ide-extensions.nix
+++ b/nix/modules/ide-extensions.nix
@@ -1,0 +1,120 @@
+{ config, lib, pkgs, ... }:
+
+let
+  commonExtensions = [
+    "alefragnani.project-manager"
+    "alexcvzz.vscode-sqlite"
+    "aliariff.auto-add-brackets"
+    "aliariff.vscode-erb-beautify"
+    "andrewmcgoveran.react-component-generator"
+    "bradlc.vscode-tailwindcss"
+    "davidanson.vscode-markdownlint"
+    "dbaeumer.vscode-eslint"
+    "donjayamanne.githistory"
+    "eamodio.gitlens"
+    "esbenp.prettier-vscode"
+    "github.vscode-github-actions"
+    "github.vscode-pull-request-github"
+    "golang.go"
+    "graphql.vscode-graphql"
+    "graphql.vscode-graphql-syntax"
+    "gruntfuggly.todo-tree"
+    "gusto.packwerk-vscode"
+    "itarato.byesig"
+    "janisdd.vscode-edit-csv"
+    "kenhowardpdx.vscode-gist"
+    "koichisasada.vscode-rdbg"
+    "mechatroner.rainbow-csv"
+    "mrmlnc.vscode-scss"
+    "ms-azuretools.vscode-containers"
+    "ms-python.debugpy"
+    "ms-python.isort"
+    "ms-python.python"
+    "ms-python.vscode-pylance"
+    "ms-vscode-remote.remote-containers"
+    "ms-vscode-remote.remote-ssh"
+    "ms-vscode-remote.remote-ssh-edit"
+    "ms-vscode.atom-keybindings"
+    "ms-vscode.remote-explorer"
+    "redhat.vscode-xml"
+    "redhat.vscode-yaml"
+    "rioj7.regex-text-gen"
+    "shopify.polaris-for-vscode"
+    "shopify.ruby-extensions-pack"
+    "shopify.ruby-lsp"
+    "sorbet.sorbet-vscode-extension"
+    "stylelint.vscode-stylelint"
+    "tamasfe.even-better-toml"
+    "wakatime.vscode-wakatime"
+    "wayou.vscode-todo-highlight"
+    "yzhang.markdown-all-in-one"
+  ];
+
+  vscodeOnlyExtensions = [
+    "graphite.gti-vscode"
+    "hverlin.mise-vscode"
+  ];
+
+  cursorOnlyExtensions = [
+    "anthropic.claude-code"
+    "anysphere.cursorpyright"
+    "anysphere.pyright"
+    "bbenoist.nix"
+    "editorconfig.editorconfig"
+    "ms-azuretools.vscode-docker"
+    "orta.vscode-jest"
+  ];
+
+  vscodeExtensions = builtins.concatLists [ commonExtensions vscodeOnlyExtensions ];
+  cursorExtensions = builtins.concatLists [ commonExtensions cursorOnlyExtensions ];
+in
+{
+  home.activation.installEditorsExtensions = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    set -euo pipefail
+
+    install_exts() {
+      local cli="$1"; shift
+      local desired_exts="$1"; shift || true
+      if [ ! -x "$cli" ]; then
+        return 0
+      fi
+      local installed
+      installed="$($cli --list-extensions 2>/dev/null | tr -d '\r' | sort -u || true)"
+      while IFS= read -r ext; do
+        [ -z "${ext:-}" ] && continue
+        if ! grep -qx "$ext" <<<"$installed"; then
+          "$cli" --install-extension "$ext" >/dev/null 2>&1 || true
+        fi
+      done <<<"$desired_exts"
+    }
+
+    vscode_exts='${lib.concatStringsSep "\n" vscodeExtensions}'
+    cursor_exts='${lib.concatStringsSep "\n" cursorExtensions}'
+
+    vscode_cli=""
+    if command -v code >/dev/null 2>&1; then
+      vscode_cli="$(command -v code)"
+    elif [ -x "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code" ]; then
+      vscode_cli="/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code"
+    fi
+
+    cursor_cli=""
+    if command -v cursor >/dev/null 2>&1; then
+      cursor_cli="$(command -v cursor)"
+    elif [ -x "/Applications/Cursor.app/Contents/Resources/app/bin/cursor" ]; then
+      cursor_cli="/Applications/Cursor.app/Contents/Resources/app/bin/cursor"
+    elif [ -x "/Applications/Cursor.app/Contents/Resources/app/bin/code" ]; then
+      cursor_cli="/Applications/Cursor.app/Contents/Resources/app/bin/code"
+    fi
+
+    if [ -n "$vscode_cli" ]; then
+      install_exts "$vscode_cli" "$vscode_exts"
+    fi
+
+    if [ -n "$cursor_cli" ]; then
+      install_exts "$cursor_cli" "$cursor_exts"
+    fi
+  '';
+}
+
+

--- a/nix/modules/vscode.nix
+++ b/nix/modules/vscode.nix
@@ -1,0 +1,101 @@
+{ config, lib, pkgs, ... }:
+
+let
+  utilsLib = import ./lib.nix;
+  inherit (utilsLib) getEnvOrFallback;
+  fullName = getEnvOrFallback "NIX_FULL_NAME" "bootstrap-user" "placeholder-user";
+in
+{
+  home.file = {
+    "Library/Application Support/Code/User/settings.json".text = ''
+      {
+        "workbench.startupEditor": "none",
+        "editor.inlineSuggest.enabled": false,
+        "git.autofetch": true,
+        "[ruby]": {
+          "editor.defaultFormatter": "Shopify.ruby-lsp",
+          "editor.formatOnSave": true,
+          "editor.tabSize": 2,
+          "editor.insertSpaces": true,
+          "editor.formatOnType": true,
+          "editor.semanticHighLighting.enabled": true,
+          "editor.semanticHighlighting.enabled": true,
+          "files.trimTrailingWhitespace": true,
+          "files.insertFinalNewline": true,
+          "files.trimFinalNewlines": true,
+          "editor.rulers": [120]
+        },
+        "byesig.fold": false,
+        "byesig.enabled": true,
+        "byesig.opacity": 0.5,
+        "byesig.showIcon": false,
+        "files.trimTrailingWhitespace": true,
+        "files.insertFinalNewline": true,
+        "editor.multiCursorModifier": "ctrlCmd",
+        "editor.formatOnPaste": true,
+        "editor.rulers": [120],
+        "terminal.integrated.fontFamily": "MesloLGS Nerd Font",
+        "git.enabledSmartCommit": true,
+        "editor.stickyScroll.enabled": true,
+        "[python]": { "editor.formatOnType": true },
+        "redhat.telemetry.enabled": true,
+        "workbench.colorTheme": "Spinel",
+        "ruby.rubocop.useBundler": true,
+        "security.workspace.trust.untrustedFiles": "open",
+        "markdownlint.config": {
+          "no-inline-html": false,
+          "single-h1": false
+        },
+        "git.enableSmartCommit": true,
+        "projectManager.git.baseFolders": ["/Users/${fullName}/dev"],
+        "projectManager.groupList": true,
+        "githubPullRequests.pullBranch": "never",
+        "window.zoomLevel": -1,
+        "[json]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode"
+        },
+        "remote.SSH.connectTimeout": 150,
+        "files.associations": {
+          "*.sample": "properties"
+        },
+        "shopifyGlobal.mysqlEditor": "external",
+        "workbench.editor.wrapTabs": true,
+        "scm.showHistoryGraph": false,
+        "editor.wordWrap": "on",
+        "workbench.activityBar.orientation": "vertical",
+        "editor.fontFamily": "Menlo, Monaco, 'Courier New', monospace, MesloLGS Nerd Font ",
+        "rubyLsp.rubyVersionManager": { "identifier": "mise" },
+        "diffEditor.ignoreTrimWhitespace": false,
+        "rubyLsp.enabledFeatures": {
+          "codeActions": true,
+          "diagnostics": true,
+          "documentHighlights": true,
+          "documentLink": true,
+          "documentSymbols": true,
+          "foldingRanges": true,
+          "formatting": true,
+          "hover": true,
+          "inlayHint": true,
+          "onTypeFormatting": true,
+          "selectionRanges": true,
+          "semanticHighlighting": true,
+          "completion": true,
+          "codeLens": true,
+          "definition": true,
+          "workspaceSymbol": true,
+          "signatureHelp": true,
+          "typeHierarchy": true
+        },
+        "rubyLsp.featureFlags": { "tapiocaAddon": true },
+        "rubyLsp.addonSettings": {},
+        "diffEditor.maxComputationTime": 0
+      }
+    '';
+
+    "Library/Application Support/Code/User/keybindings.json".text = ''
+      []
+    '';
+  };
+}
+
+


### PR DESCRIPTION
- Add declarative VS Code settings (no AI)\n- Add shared IDE extensions with common/vscode-only/cursor-only\n- Wire into home.nix and activation script\n- Align fonts and wordWrap for consistency