### PR TITLE
chore: disable ssh default config, raise nix download buffer, add .cursorrules

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,16 @@
+# Cursor per‑repo rules
+
+- Follow `AGENTS.md` and `CLAUDE.md` as the authoritative repo guides.
+- Prefer absolute paths in tool commands and references.
+- For macOS/Nix changes, edit files under `nix/` (modules are in `nix/modules/`).
+- Validate changes with `nix flake check ./nix` before applying.
+- Apply configuration with `nixup` (alias for `darwin-rebuild switch`).
+- Do not commit secrets; use 1Password CLI as described in `BOOTSTRAP.md`.
+- Nix style: 2‑space indentation, small focused modules, hyphenated filenames.
+- Shell scripts: `#!/bin/bash`, `set -euo pipefail`, pass shellcheck; markdown should pass markdownlint.
+
+When assisting in this repo:
+
+- Keep responses concise and skimmable; use fenced code blocks only for relevant snippets.
+- Reference files/functions with backticks (e.g., `nix/modules/ssh.nix`).
+- Default to declarative edits; avoid ad‑hoc manual system changes.

--- a/nix/modules/base-configuration.nix
+++ b/nix/modules/base-configuration.nix
@@ -3,7 +3,7 @@
 {
   # Necessary for using flakes on this system.
   nix.settings.experimental-features = "nix-command flakes";
-  nix.settings.download-buffer-size = 33554432;
+  nix.settings.download-buffer-size = 268435456; # 256 MiB
 
   # Create /etc/zshrc that loads the nix-darwin environment.
   programs.zsh.enable = true;  # default shell on catalina

--- a/nix/modules/ssh.nix
+++ b/nix/modules/ssh.nix
@@ -4,7 +4,7 @@ let
   # Import shared utilities
   lib = import ./lib.nix;
   inherit (lib) getEnvOrFallback;
-  
+
   sshDir = "${config.home.homeDirectory}/.ssh";
   username = config.home.username;
   laptopName = getEnvOrFallback "NIX_LAPTOP_NAME" "bootstrap-laptop" "placeholder-laptop";
@@ -19,25 +19,25 @@ let
   # Environment-based configurations
   personalEmail = getEnvOrFallback "NIX_PERSONAL_EMAIL" "bootstrap@example.com" "placeholder@example.com";
   privateEmail = getEnvOrFallback "NIX_PRIVATE_EMAIL" "bootstrap-alt@example.com" "placeholder-alt@example.com";
-  
+
   # Server and user names from environment
   mainServerName = getEnvOrFallback "NIX_SERVER_NAME_L" "bootstrap-server" "placeholder-server";
   nvmServerName = getEnvOrFallback "NIX_SERVER_NVM_NAME" "bootstrap-vm" "placeholder-vm";
   privateUser = getEnvOrFallback "NIX_PRIVATE_USER" "bootstrap-user" "placeholder-user";
   privateUserShort = getEnvOrFallback "NIX_PRIVATE_USER_SHORT" "bootstrap-short" "placeholder-short";
-  
+
   # Identity file names from environment
   mainServerKeyFile = getEnvOrFallback "NIX_SSH_MAIN_SERVER_KEYFILE" "bootstrap-main" "placeholder-main";
   nvmServerKeyFile = getEnvOrFallback "NIX_SSH_NVM_SERVER_KEYFILE" "bootstrap-nvm" "placeholder-nvm";
   mainGithubKeyFile = getEnvOrFallback "NIX_SSH_MAIN_GITHUB_KEYFILE" "bootstrap-main-github" "placeholder-main-github";
   privateGithubKeyFile = getEnvOrFallback "NIX_SSH_PRIVATE_GITHUB_KEYFILE" "bootstrap-private-github" "placeholder-private-github";
-  
+
   # SSH public keys from environment
   mainServerKey = getEnvOrFallback "NIX_SSH_MAIN_SERVER_KEY" "ssh-ed25519 BOOTSTRAP_MAIN_SERVER_KEY" "ssh-ed25519 PLACEHOLDER_MAIN_SERVER_KEY_CHANGE_ME";
   nvmServerKey = getEnvOrFallback "NIX_SSH_NVM_SERVER_KEY" "ssh-ed25519 BOOTSTRAP_NVM_SERVER_KEY" "ssh-ed25519 PLACEHOLDER_NVM_SERVER_KEY_CHANGE_ME";
   mainGithubKey = getEnvOrFallback "NIX_SSH_MAIN_GITHUB_KEY" "ssh-ed25519 BOOTSTRAP_MAIN_GITHUB_KEY" "ssh-ed25519 PLACEHOLDER_MAIN_GITHUB_KEY_CHANGE_ME";
   privateGithubKey = getEnvOrFallback "NIX_SSH_PRIVATE_GITHUB_KEY" "ssh-ed25519 BOOTSTRAP_PRIVATE_GITHUB_KEY" "ssh-ed25519 PLACEHOLDER_PRIVATE_GITHUB_KEY_CHANGE_ME";
-  
+
   # Common configurations
   common = {
     private = {
@@ -52,10 +52,10 @@ let
 
 in
 {
-  programs.ssh = 
+  programs.ssh =
     let
-      
-      # Helper for NVM server with remote commands  
+
+      # Helper for NVM server with remote commands
       mkNvmBlock = suffix: remoteCmd: {
         "${nvmServerName}${suffix}" = {
           hostname = ips.nvm_server;
@@ -66,12 +66,12 @@ in
           };
         };
       };
-      
+
       # Base server blocks
       baseBlocks = {
         "${mainServerName}" = {
           hostname = ips.main_server;
-          user = "root";  
+          user = "root";
           port = 8822;
           identityFile = "~/.ssh/${mainServerKeyFile}";
         };
@@ -82,31 +82,31 @@ in
           identityFile = "~/.ssh/${nvmServerKeyFile}";
         };
       } else {});
-      
+
       # NVM-specific blocks (only if configured)
       nvmBlocks = if ips.nvm_server != "192.168.y.y" then
         mkNvmBlock "-up" "cd /mnt/torrents/complete-seed/${privateUser}/" //
         mkNvmBlock "-down" "cd /mnt/unmanic/staging"
       else {};
-      
+
     in {
       enable = true;
+      enableDefaultConfig = false;
       matchBlocks = baseBlocks // nvmBlocks // {
-      "github.com" = {
-        hostname = "github.com";
-        identityFile = "~/.ssh/${mainGithubKeyFile}";
-      };
-      "github.${privateUserShort}" = {
-        hostname = "github.com";
-        identityFile = "~/.ssh/${privateGithubKeyFile}";
+        "*" = {
+          identityAgent = "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock";
+          identitiesOnly = true;
+        };
+        "github.com" = {
+          hostname = "github.com";
+          identityFile = "~/.ssh/${mainGithubKeyFile}";
+        };
+        "github.${privateUserShort}" = {
+          hostname = "github.com";
+          identityFile = "~/.ssh/${privateGithubKeyFile}";
+        };
       };
     };
-    extraConfig = ''
-      Host *
-        IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
-        IdentitiesOnly yes
-    '';
-  };
 
   home.file = {
     "${sshDir}/${mainServerKeyFile}.pub".text = "${mainServerKey} ${macbook_hostname}";


### PR DESCRIPTION
- Disable Home Manager SSH default config; add explicit "*" match block
- Increase nix download buffer to 256 MiB
- Add per-repo Cursor rules in `.cursorrules`

Checklist:
- [x] `nix flake check ./nix` passes locally
- [x] No secrets added
- [x] Docs: rules centralized in `.cursorrules`, `AGENTS.md`, `CLAUDE.md`
