### PR TITLE
chore(nix): optimize flake outputs, caches, mise and extensions

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -22,7 +22,7 @@
       # Import shared utilities
       lib = import ./modules/lib.nix;
       inherit (lib) getEnvOrFallback;
-      
+
       # Environment-based username with fallback using consistent pattern
       username = getEnvOrFallback "NIX_FULL_NAME" "bootstrap-user" "placeholder-user";
       homeDirectory = "/Users/${username}";
@@ -62,7 +62,10 @@
       specialArgs = commonConfig;
     };
 
-    # Expose the package set, including overlays, for convenience.
-    darwinPackages = self.darwinConfigurations."macbook_setup".pkgs;
+    # Expose the package set under a standard flake output to avoid warnings.
+    legacyPackages.aarch64-darwin = self.darwinConfigurations."macbook_setup".pkgs;
+
+    # Provide a formatter for `nix fmt`
+    formatter.aarch64-darwin = nixpkgs.legacyPackages.aarch64-darwin.nixfmt;
   };
 }

--- a/nix/modules/base-configuration.nix
+++ b/nix/modules/base-configuration.nix
@@ -4,6 +4,14 @@
   # Necessary for using flakes on this system.
   nix.settings.experimental-features = "nix-command flakes";
   nix.settings.download-buffer-size = 268435456; # 256 MiB
+  nix.settings.auto-optimise-store = true;
+  nix.settings.extra-substituters = [
+    "https://cache.nixos.org/"
+    "https://nix-community.cachix.org"
+  ];
+  nix.settings.extra-trusted-public-keys = [
+    "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+  ];
 
   # Create /etc/zshrc that loads the nix-darwin environment.
   programs.zsh.enable = true;  # default shell on catalina

--- a/nix/modules/mise.nix
+++ b/nix/modules/mise.nix
@@ -16,6 +16,4 @@
       };
     };
   };
-
-  home.file.".local/bin/mise".source = "${pkgs.mise}/bin/mise";
 }


### PR DESCRIPTION
This PR:
- Move to standard flake output: legacyPackages.aarch64-darwin (removes unknown output warning)
- Add formatter output (nixfmt) for nix fmt
- Enable auto-optimise-store and nix-community cachix cache
- Remove redundant mise symlink (shell integration already wraps)
- Update editor extensions activation to uninstall removed and force-update installed