### PR TITLE
feat(bin): keep sudo alive to avoid second prompt during nixup

### DIFF
--- a/bin/nixup-with-secrets
+++ b/bin/nixup-with-secrets
@@ -253,12 +253,20 @@ main() {
     echo "🏠 Nix Dotfiles Configuration Manager"
     echo "======================================"
 
+    # Obtain sudo once up front and keep the timestamp fresh to avoid re-prompts
+    if sudo -v; then
+        # Keep sudo alive until this script exits
+        while true; do sudo -n true; sleep 60; done 2>/dev/null &
+        SUDO_KEEPALIVE_PID=$!
+        trap 'kill -9 ${SUDO_KEEPALIVE_PID} >/dev/null 2>&1 || true' EXIT
+    fi
+
     if is_fresh_system; then
         run_bootstrap "$@"
     else
         if load_secrets; then
             print_status "Applying configuration with secrets..."
-            if sudo -E darwin-rebuild switch --flake ~/dotfiles/nix#macbook_setup --impure "$@"; then
+            if sudo -n -E darwin-rebuild switch --flake ~/dotfiles/nix#macbook_setup --impure "$@"; then
                 print_success "Configuration applied successfully!"
             else
                 print_error "Configuration build failed!"


### PR DESCRIPTION
- Prompt once with `sudo -v` and keep credential alive in background
- Use `sudo -n` for `darwin-rebuild` to avoid a second prompt
- Cleanly kill keepalive on exit

This preserves functionality but reduces auth friction during `nixup`.