### PR TITLE
Revert: feat(bin): keep sudo alive to avoid second prompt during nixup

### DIFF
--- a/bin/nixup-with-secrets
+++ b/bin/nixup-with-secrets
@@ -253,20 +253,12 @@ main() {
     echo "🏠 Nix Dotfiles Configuration Manager"
     echo "======================================"
 
-    # Obtain sudo once up front and keep the timestamp fresh to avoid re-prompts
-    if sudo -v; then
-        # Keep sudo alive until this script exits
-        while true; do sudo -n true; sleep 60; done 2>/dev/null &
-        SUDO_KEEPALIVE_PID=$!
-        trap 'kill -9 ${SUDO_KEEPALIVE_PID} >/dev/null 2>&1 || true' EXIT
-    fi
-
     if is_fresh_system; then
         run_bootstrap "$@"
     else
         if load_secrets; then
             print_status "Applying configuration with secrets..."
-            if sudo -n -E darwin-rebuild switch --flake ~/dotfiles/nix#macbook_setup --impure "$@"; then
+            if sudo -E darwin-rebuild switch --flake ~/dotfiles/nix#macbook_setup --impure "$@"; then
                 print_success "Configuration applied successfully!"
             else
                 print_error "Configuration build failed!"


### PR DESCRIPTION
Reverts commit 6c2d0fa522a616d95fa1490dac03f0852a014609 (PR #31).

Context: This change caused extra complexity and did not resolve double prompts reliably. We'll revisit sudo UX later; for now, restoring previous behavior.