### PR TITLE
Revert: fix(bin): remove sudo -E to avoid env preserve error

### DIFF
--- a/bin/nixup-with-secrets
+++ b/bin/nixup-with-secrets
@@ -68,7 +68,7 @@ run_bootstrap() {
     export NIX_BOOTSTRAP_MODE=1
 
     # Run darwin-rebuild in bootstrap mode
-    if sudo darwin-rebuild switch --flake ~/dotfiles/nix#macbook_setup --impure "$@"; then
+    if sudo -E darwin-rebuild switch --flake ~/dotfiles/nix#macbook_setup --impure "$@"; then
         print_success "Bootstrap complete!"
         echo ""
         print_status "Next steps:"
@@ -258,7 +258,7 @@ main() {
     else
         if load_secrets; then
             print_status "Applying configuration with secrets..."
-            if sudo darwin-rebuild switch --flake ~/dotfiles/nix#macbook_setup --impure "$@"; then
+            if sudo -E darwin-rebuild switch --flake ~/dotfiles/nix#macbook_setup --impure "$@"; then
                 print_success "Configuration applied successfully!"
             else
                 print_error "Configuration build failed!"
@@ -268,7 +268,7 @@ main() {
             print_error "Failed to load secrets. Configuration not applied."
             echo ""
             print_status "You can still run in bootstrap mode with:"
-            echo "  ${BLUE}NIX_BOOTSTRAP_MODE=1 sudo darwin-rebuild switch --flake ~/dotfiles/nix#macbook_setup --impure${NC}"
+            echo "  ${BLUE}NIX_BOOTSTRAP_MODE=1 sudo -E darwin-rebuild switch --flake ~/dotfiles/nix#macbook_setup --impure${NC}"
             exit 1
         fi
     fi


### PR DESCRIPTION
Revert PR #34 to restore previous behavior while we fully roll back to a known-good state.

We will re-apply any necessary fixes in a separate, minimal PR once the repo is stable.