### PR TITLE
feat(mise,cursor,vscode,nixup): GUI-ready mise + Ruby LSP path, env preserve

### DIFF
--- a/bin/nixup-with-secrets
+++ b/bin/nixup-with-secrets
@@ -67,8 +67,8 @@ run_bootstrap() {
 
     export NIX_BOOTSTRAP_MODE=1
 
-    # Run darwin-rebuild in bootstrap mode
-    if sudo darwin-rebuild switch --flake ~/dotfiles/nix#macbook_setup --impure "$@"; then
+    # In bootstrap we only need to preserve the bootstrap flag
+    if sudo --preserve-env=NIX_BOOTSTRAP_MODE darwin-rebuild switch --flake ~/dotfiles/nix#macbook_setup --impure "$@"; then
         print_success "Bootstrap complete!"
         echo ""
         print_status "Next steps:"
@@ -218,6 +218,15 @@ load_secrets() {
         export "$export_var"
     done
 
+    # Build a comma-separated list of variable names for sudo --preserve-env
+    # Strip the '=value' suffix from each item in export_vars
+    local names=()
+    for kv in "${export_vars[@]}"; do
+        names+=("${kv%%=*}")
+    done
+    PRESERVE_NIX_VARS=$(IFS=, ; echo "${names[*]}")
+    export PRESERVE_NIX_VARS
+
     # Special validation for complete private ID configuration
     if [[ $private_loaded -eq $private_secrets && $private_secrets -gt 0 ]]; then
         print_success "Complete private ID configuration loaded"
@@ -258,7 +267,8 @@ main() {
     else
         if load_secrets; then
             print_status "Applying configuration with secrets..."
-            if sudo darwin-rebuild switch --flake ~/dotfiles/nix#macbook_setup --impure "$@"; then
+            # Preserve only the NIX_* vars we exported from 1Password
+            if sudo --preserve-env="${PRESERVE_NIX_VARS}" darwin-rebuild switch --flake ~/dotfiles/nix#macbook_setup --impure "$@"; then
                 print_success "Configuration applied successfully!"
             else
                 print_error "Configuration build failed!"

--- a/nix/modules/cursor.nix
+++ b/nix/modules/cursor.nix
@@ -105,7 +105,8 @@ in
         "workbench.activityBar.orientation": "vertical",
         "editor.fontFamily": "Menlo, Monaco, 'Courier New', monospace, MesloLGS Nerd Font ",
         "rubyLsp.rubyVersionManager": {
-          "identifier": "mise"
+          "identifier": "mise",
+          "path": "/Users/${fullName}/.local/bin/mise"
         },
         "diffEditor.ignoreTrimWhitespace": false,
         "rubyLsp.enabledFeatures": {

--- a/nix/modules/mise.nix
+++ b/nix/modules/mise.nix
@@ -16,4 +16,11 @@
       };
     };
   };
+
+  # Ensure Ruby LSP can find mise when launched from GUI apps like Cursor.
+  # Ruby LSP looks for mise in ~/.local/bin, /opt/homebrew/bin, or /usr/bin.
+  # Since mise is installed via Nix in the store, provide a stable symlink.
+  home.file = {
+    ".local/bin/mise".source = "${pkgs.mise}/bin/mise";
+  };
 }

--- a/nix/modules/vscode.nix
+++ b/nix/modules/vscode.nix
@@ -66,7 +66,7 @@ in
         "editor.wordWrap": "on",
         "workbench.activityBar.orientation": "vertical",
         "editor.fontFamily": "Menlo, Monaco, 'Courier New', monospace, MesloLGS Nerd Font ",
-        "rubyLsp.rubyVersionManager": { "identifier": "mise" },
+        "rubyLsp.rubyVersionManager": { "identifier": "mise", "path": "/Users/${fullName}/.local/bin/mise" },
         "diffEditor.ignoreTrimWhitespace": false,
         "rubyLsp.enabledFeatures": {
           "codeActions": true,


### PR DESCRIPTION
Summary
- Ensure GUI apps (Cursor/VS Code) can find mise reliably by linking ~/.local/bin/mise via Home Manager
- Configure Ruby LSP to use mise (and explicit path) in Cursor and VS Code settings
- Make nixup preserve only exported NIX_* env vars across sudo; simplify bootstrap preservation

Changes
- nix/modules/mise.nix: add home.file symlink: ~/.local/bin/mise -> ${pkgs.mise}/bin/mise
- nix/modules/cursor.nix: set rubyLsp.rubyVersionManager.identifier=mise and path to ~/.local/bin/mise
- nix/modules/vscode.nix: same Ruby LSP mise configuration
- bin/nixup-with-secrets: compute list of exported NIX_* vars, pass with sudo --preserve-env; use only NIX_BOOTSTRAP_MODE in bootstrap

Rationale
- Ruby LSP in GUI apps commonly searches ~/.local/bin; Nix store binaries are not on PATH for launchd apps. Symlink guarantees discoverability.
- Explicit Ruby LSP path removes ambiguity and eliminates prompts.
- Sudo does not expand globs for --preserve-env; passing exact names avoids fallback to placeholder-user and is safer.

Testing
- Verified 1Password CLI sign-in and fetched required fields
- Ran nixup end-to-end: configuration applied successfully; Home Manager linked ~/.local/bin/mise
- Confirmed `command -v mise` and symlink presence

Apply
- nixup
- Restart Cursor/VS Code if they were open to pick up settings

Notes
- No secrets committed. Follows repo guidelines and uses 2-space Nix indentation.