### PR TITLE
chore(nix): update flake inputs

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -2,7 +2,7 @@
 
 - Follow `AGENTS.md` and `CLAUDE.md` as the authoritative repo guides.
 - Prefer absolute paths in tool commands and references.
-- For macOS/Nix changes, edit files under `nix/` (modules are in `nix/modules/`).
+- For macOS/Nix changes, edit files under `nix/` (modules are in `nix/modules/system` and `nix/modules/home`).
 - Validate changes with `nix flake check ./nix` before applying.
 - Apply configuration with `nixup` (alias for `darwin-rebuild switch`).
 - Do not commit secrets; use 1Password CLI as described in `BOOTSTRAP.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 - `nix/flake.nix`: Main flake; entry point for builds.
 - `nix/home.nix`: Home Manager imports.
-- `nix/modules/*.nix`: Modular configs (e.g., `homebrew.nix`, `system-defaults.nix`, `git.nix`, `cursor.nix`).
+- `nix/modules/system/*.nix` and `nix/modules/home/*.nix`: Modular configs (e.g., `system/homebrew.nix`, `system/system-defaults.nix`, `home/git.nix`, `home/cursor.nix`).
 - `nix/files/`: Static assets (fonts, PWA apps, etc.).
 - `bin/`: Utility scripts (e.g., `nixup-with-secrets`, `gbclean`).
 - `bootstrap.sh` + `BOOTSTRAP.md`: First‑time setup and 1Password bootstrap.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,8 @@
 
 - `nix/flake.nix`: Main flake configuration
 - `nix/home.nix`: Home Manager configuration imports
-- `nix/modules/`: Individual configuration modules
-- `nix/modules/claude.nix`: Claude Code settings and permissions
+- `nix/modules/system/` and `nix/modules/home/`: Individual configuration modules
+- `nix/modules/home/claude.nix`: Claude Code settings and permissions
 
 ## Code Standards
 
@@ -23,17 +23,17 @@
 
 ## Key Modules
 
-- `starship.nix`: Terminal prompt configuration
-- `zsh.nix`: Shell and environment setup (includes Claude env vars)
-- `claude.nix`: Claude Code settings and permissions
-- `git.nix`: Git configuration
-- `homebrew.nix`: macOS app management
-- `packages.nix`: System packages
-- `system-defaults.nix`: macOS system preferences
+- `home/starship.nix`: Terminal prompt configuration
+- `home/zsh.nix`: Shell and environment setup (includes Claude env vars)
+- `home/claude.nix`: Claude Code settings and permissions
+- `home/git.nix`: Git configuration
+- `system/homebrew.nix`: macOS app management
+- `system/packages.nix`: System packages
+- `system/system-defaults.nix`: macOS system preferences
 
 ## Workflow
 
-- Test changes with `nix flake check ~/dotfiles/nix` before applying
+- Test changes with `nix flake check ./nix` before applying
 - Use `nixup` to apply system-wide changes
 - Configuration is declarative - edit nix files, don't manually configure
 - Claude environment variables are managed in `zsh.nix`

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ darwin-rebuild switch --flake ~/dotfiles/nix#macbook_setup
 ### Applications (85+ apps via Homebrew)
 
 - **Development**: Cursor, VS Code, Docker, Postman, Proxyman
-- **Communication**: Discord, Slack, Signal, WhatsApp, Telegram  
+- **Communication**: Discord, Slack, Signal, WhatsApp, Telegram
 - **Media**: VLC, HandBrake, Steam, Plex
 - **Productivity**: 1Password, Rectangle, Obsidian, Logseq
 - **System**: Tailscale, LuLu, Gas Mask, CleanMyMac
@@ -47,7 +47,7 @@ darwin-rebuild switch --flake ~/dotfiles/nix#macbook_setup
 ### System Configuration
 
 - **Dock**: Custom app layout and settings
-- **Trackpad**: Natural scrolling, force click settings  
+- **Trackpad**: Natural scrolling, force click settings
 - **Finder**: Show extensions, status bar configuration
 - **Fonts**: Nerd Fonts + custom fonts (PlayfairDisplay, etc.)
 
@@ -64,14 +64,14 @@ After running the bootstrap:
 
 1. **Restart your terminal** to load new shell configuration
 2. **Sign into applications** that require authentication
-3. **Configure 1Password** for SSH/Git signing
+3. **Configure 1Password** for SSH/Git signing (see `BOOTSTRAP.md` for required items and environment variables)
 4. **Run `nixup`** to rebuild configuration (alias for darwin-rebuild)
 
 ## 🛠 Customization
 
 ### Adding Applications
 
-Edit `nix/modules/homebrew.nix` to add new casks:
+Edit `nix/modules/system/homebrew.nix` to add new casks:
 
 ```nix
 casks = [
@@ -82,11 +82,11 @@ casks = [
 
 ### Modifying System Settings
 
-Edit `nix/modules/system-defaults.nix` for system preferences.
+Edit `nix/modules/system/system-defaults.nix` for system preferences.
 
 ### Updating Development Tools
 
-Edit `nix/modules/mise.nix` to manage language versions.
+Edit `nix/modules/home/mise.nix` to manage language versions.
 
 ## 📱 Available Commands
 
@@ -106,17 +106,22 @@ nixup
 
 ```text
 ├── nix/
-│   ├── flake.nix              # Main flake configuration
-│   ├── home.nix               # Home-manager config
-│   ├── modules/               # Modular configurations
-│   │   ├── homebrew.nix       # Applications
-│   │   ├── system-defaults.nix # System settings
-│   │   ├── git.nix            # Git configuration
-│   │   ├── cursor.nix         # Cursor settings
-│   │   └── ...
-│   └── files/                 # Static files (fonts, etc.)
-├── bootstrap.sh               # Setup script
-└── README.md                  # This file
+│   ├── flake.nix                      # Main flake configuration
+│   ├── home.nix                       # Home Manager imports
+│   ├── modules/
+│   │   ├── system/                    # nix-darwin (system-wide)
+│   │   │   ├── homebrew.nix           # Applications (casks)
+│   │   │   ├── system-defaults.nix    # macOS system settings
+│   │   │   ├── packages.nix           # System packages
+│   │   │   └── ...
+│   │   └── home/                      # Home Manager (user)
+│   │       ├── cursor.nix             # Cursor settings
+│   │       ├── git.nix                # Git configuration
+│   │       ├── mise.nix               # Language/runtime manager
+│   │       └── ...
+│   └── files/                         # Static files (fonts, PWAs, etc.)
+├── bootstrap.sh                       # Setup script
+└── README.md                          # This file
 ```
 
 ## 🆘 Troubleshooting
@@ -137,8 +142,8 @@ echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
 
 #### Applications not found
 
-- Run `brew bundle` in the repository directory
-- Check homebrew.nix for typos in cask names
+- Run `nixup` to reapply Homebrew casks via nix-homebrew
+- Check `nix/modules/system/homebrew.nix` for typos in cask names
 
 ### Getting Help
 
@@ -162,7 +167,7 @@ echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
 ## 🌟 Features
 
 - ✅ **Declarative**: Everything defined in configuration files
-- ✅ **Reproducible**: Same setup on any macOS machine  
+- ✅ **Reproducible**: Same setup on any macOS machine
 - ✅ **Rollback**: Previous configurations always available
 - ✅ **Modular**: Easy to enable/disable components
 - ✅ **Version-controlled**: Track all system changes in git

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -24,11 +24,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757598712,
-        "narHash": "sha256-5PWVrdMp8u31Q247jqnJcwxKg3MJrs1TadTyTBRVBDY=",
+        "lastModified": 1757997814,
+        "narHash": "sha256-F+1aoG+3NH4jDDEmhnDUReISyq6kQBBuktTUqCUWSiw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6d7c11a0adee0db21e3a8ef90ae07bb89bc20b8f",
+        "rev": "5820376beb804de9acf07debaaff1ac84728b708",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757034884,
-        "narHash": "sha256-PgLSZDBEWUHpfTRfFyklmiiLBE1i1aGCtz4eRA3POao=",
+        "lastModified": 1757967192,
+        "narHash": "sha256-/aA9A/OBmnuOMgwfzdsXRusqzUpd8rQnQY8jtrHK+To=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ca77296380960cd497a765102eeb1356eb80fed0",
+        "rev": "0d7c15863b251a7a50265e57c1dca1a7add2e291",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
- Update flake inputs for `nixpkgs` and `home-manager`
- Validate with `nix flake check nix`

Note: Could not apply locally via `nixup` from this session due to sudo requirement; please run `nixup` locally to apply.