### PR TITLE
feat(cursor,homebrew): manage Cursor keybindings via nix and switch to Shottr

### DIFF
--- a/nix/modules/system/homebrew.nix
+++ b/nix/modules/system/homebrew.nix
@@ -58,6 +58,7 @@
       "scummvm-app"
       "sequel-ace"
       "session"
+      "shottr"
       "signal"
       "slack"
       "steam"
@@ -84,7 +85,6 @@
         "Deliveries" = 290986013;
         "JSON Peep for Safari" = 1458969831;
         "MetaDoctor" = 988250390;
-        "Monosnap - screenshot editor" = 540348655;
         "Numbers" = 409203825;
         "Pages" = 409201541;
         "Proton Pass for Safari" = 6502835663;


### PR DESCRIPTION
- Add Cursor `keybindings.json` management via `nix/modules/home/cursor.nix`, setting `cmd+i` to `composerMode.agent`.
- Replace Monosnap with Shottr in Homebrew casks (Shottr already present; ensuring it's set).

Validation:
- Ran `nix flake check ./nix` locally; outputs evaluated successfully.

Apply with `nixup`.

No secrets; small declarative changes per repo rules.