### PR TITLE
fix: remove duplicate success message in nx apply command

### DIFF
--- a/bin/nx
+++ b/bin/nx
@@ -67,7 +67,7 @@ update_flake() {
 apply_config() {
     log_info "Applying nix-darwin configuration..."
     if nixup-with-secrets; then
-        log_success "Configuration applied successfully"
+        # nixup-with-secrets already prints success message
         return 0
     else
         log_error "Configuration apply failed"


### PR DESCRIPTION
## Summary
Fixes duplicate "Configuration applied successfully!" messages when running `nx up` command.

## Problem
Currently when running `nx up`, users see two identical success messages:
```
Activating setDarwinDefaults
Activating setupLaunchAgents
[SUCCESS] Configuration applied successfully!
[SUCCESS] Configuration applied successfully
```

## Root Cause
Both `nixup-with-secrets` script and the `apply_config` function in the `nx` script were printing their own success messages:
- `nixup-with-secrets` prints: "Configuration applied successfully!" (line 272)
- `nx` script prints: "Configuration applied successfully" (line 70)

## Solution
- Remove the duplicate success message from the `nx` script's `apply_config` function
- Let `nixup-with-secrets` handle the success messaging since it has more context about what was actually applied
- Add a comment explaining why we don't print a success message

## Result
Users will now see only one success message:
```
Activating setDarwinDefaults
Activating setupLaunchAgents
[SUCCESS] Configuration applied successfully!
```

## Test Plan
- [x] Verify `nx up` only shows one success message
- [x] Verify error handling still works correctly
- [x] Verify other nx commands are unaffected