### PR TITLE
fix: resolve Cursor keybindings atomic write error

### DIFF
--- a/nix/modules/home/cursor.nix
+++ b/nix/modules/home/cursor.nix
@@ -139,22 +139,30 @@ in
 
     # GitHub MCP configuration for Cursor (pretty-formatted)
     ".cursor/mcp.json".source = cursorMcpJson;
-
-    "Library/Application Support/Cursor/User/keybindings.json" = {
-      text = ''
-        [
-          {
-            "key": "cmd+i",
-            "command": "composerMode.agent"
-          },
-          {
-            "key": "cmd+e",
-            "command": "composerMode.background"
-          }
-        ]
-      '';
-      # Allow Cursor to modify this file
-      force = false;
-    };
   };
+
+  # Create initial keybindings file that Cursor can manage
+  home.activation.cursorKeybindings = lib.hm.dag.entryAfter ["writeBoundary"] ''
+    $DRY_RUN_CMD mkdir -p "$HOME/Library/Application Support/Cursor/User"
+
+    KEYBINDINGS_FILE="$HOME/Library/Application Support/Cursor/User/keybindings.json"
+
+    # Only create the file if it doesn't exist or if it's a symlink (from previous Nix management)
+    if [[ ! -f "$KEYBINDINGS_FILE" || -L "$KEYBINDINGS_FILE" ]]; then
+      $VERBOSE_ECHO "Creating initial Cursor keybindings file"
+      $DRY_RUN_CMD rm -f "$KEYBINDINGS_FILE"  # Remove symlink if it exists
+      $DRY_RUN_CMD cat > "$KEYBINDINGS_FILE" << 'EOF'
+[
+  {
+    "key": "cmd+i",
+    "command": "composerMode.agent"
+  },
+  {
+    "key": "cmd+e",
+    "command": "composerMode.background"
+  }
+]
+EOF
+    fi
+  '';
 }


### PR DESCRIPTION
## Summary
Fixes the "Unable to unlock file because atomic write is enabled" error when Cursor tries to modify keybindings.json.

## Problem
After the previous fix attempt, users still see this error:
```
Failed to save 'keybindings.json': Unable to write file 'vscode-userdata:/Users/.../keybindings.json' (Error: Unable to unlock file because atomic write is enabled.)
```

This happens because:
- Home Manager creates keybindings.json as a **symlink** to the Nix store
- Cursor cannot write to symlinks pointing to the read-only Nix store
- The `force = false` setting doesn't work for symlinked files

## Root Cause
```bash
$ ls -la ~/Library/Application\ Support/Cursor/User/keybindings.json
lrwxr-xr-x@ ... -> /nix/store/.../keybindings.json
```
The file is a symlink to the immutable Nix store, making it impossible for Cursor to modify.

## Solution
**Stop managing keybindings.json with Nix entirely:**
- Remove the file from `home.file` management
- Add a `home.activation` script that creates an initial keybindings file **once**
- Let Cursor have full control over the file after initial creation

**The activation script:**
- Only runs if the file doesn't exist or is a symlink (from previous Nix management)
- Removes any existing symlink
- Creates a regular file with initial keybindings
- Never overwrites user modifications

## Benefits
- ✅ Cursor can freely modify keybindings (no more atomic write errors)
- ✅ Initial keybindings (cmd+i, cmd+e) are still provided
- ✅ User customizations are preserved
- ✅ No more read-only file conflicts
- ✅ Follows the principle: "Nix provides defaults, user controls runtime"

## Test Plan
- [x] Verify flake configuration is valid
- [ ] Apply configuration and verify symlink is replaced with regular file
- [ ] Verify Cursor can modify keybindings without errors
- [ ] Verify initial keybindings (cmd+i, cmd+e) work
- [ ] Verify user can add custom keybindings