### PR TITLE
Fix zoxide doctor warnings in non-interactive shells

### DIFF
--- a/nix/modules/home/zsh.nix
+++ b/nix/modules/home/zsh.nix
@@ -82,7 +82,12 @@ in
       eval "$(pay-respects zsh --alias)"
 
       # Initialize zoxide only in interactive shells
-      [[ $- == *i* ]] && eval "$(${pkgs.zoxide}/bin/zoxide init zsh --cmd cd)"
+      if [[ $- == *i* ]]; then
+        eval "$(${pkgs.zoxide}/bin/zoxide init zsh --cmd cd)"
+      else
+        # Disable zoxide doctor warnings in non-interactive shells
+        export _ZO_DOCTOR=0
+      fi
     '';
 
     shellAliases = {};


### PR DESCRIPTION
## Problem

Zoxide was showing doctor warnings every time Cursor executed terminal commands:

```
zoxide: detected a possible configuration issue.
Please ensure that zoxide is initialized right at the end of your shell configuration file (usually ~/.zshrc).

If the issue persists, consider filing an issue at:
https://github.com/ajeetdsouza/zoxide/issues

Disable this message by setting _ZO_DOCTOR=0.
```

## Solution

- Added conditional logic to only disable `_ZO_DOCTOR` warnings in **non-interactive shells**
- Preserves full zoxide functionality and helpful warnings in interactive terminal sessions
- Follows zoxide's recommended solution for non-interactive environments

## Changes

- Modified `nix/modules/home/zsh.nix` to conditionally export `_ZO_DOCTOR=0` only when not in interactive mode
- Interactive shells: zoxide initializes normally with full functionality
- Non-interactive shells (like Cursor commands): doctor warnings are suppressed

## Testing

- `nx check` passes
- Configuration is syntactically valid
- Ready to apply with `nx up`