### PR TITLE
feat: add Docker Compose language settings to Cursor

### DIFF
--- a/nix/modules/home/cursor.nix
+++ b/nix/modules/home/cursor.nix
@@ -133,7 +133,18 @@ in
         "rubyLsp.addonSettings": {},
         "diffEditor.maxComputationTime": 0,
         "keyboard.dispatch": "keyCode",
-        "settingsSync.keybindingsPerPlatform": false
+        "settingsSync.keybindingsPerPlatform": false,
+        "[dockercompose]": {
+          "editor.insertSpaces": true,
+          "editor.tabSize": 2,
+          "editor.autoIndent": "advanced",
+          "editor.quickSuggestions": {
+            "other": true,
+            "comments": false,
+            "strings": true
+          },
+          "editor.defaultFormatter": "redhat.vscode-yaml"
+        }
       }
     '';
 


### PR DESCRIPTION
## Summary

Adds Docker Compose language-specific configuration to Cursor that was auto-suggested by the editor.

## Changes

- **Added `[dockercompose]` language settings** to `nix/modules/home/cursor.nix`:
  - `editor.insertSpaces: true` - Use spaces instead of tabs
  - `editor.tabSize: 2` - Set indentation to 2 spaces
  - `editor.autoIndent: "advanced"` - Enable advanced auto-indentation
  - `editor.quickSuggestions` - Configure IntelliSense for different contexts
  - `editor.defaultFormatter: "redhat.vscode-yaml"` - Use Red Hat YAML formatter

## Benefits

- Improves editing experience for Docker Compose files
- Consistent formatting and indentation
- Better IntelliSense support
- Automatic YAML formatting

## Testing

- [ ] Run `nx check` to validate Nix syntax
- [ ] Apply with `nixup` to test configuration
- [ ] Verify Docker Compose file editing behavior in Cursor