### PR TITLE
Add pkg-config to system packages

### DIFF
--- a/nix/modules/system/packages.nix
+++ b/nix/modules/system/packages.nix
@@ -17,6 +17,7 @@ let
     mkalias
     nodejs
     openssl
+    pkg-config
     pnpm
     rclone
     rsync


### PR DESCRIPTION
## Summary
- Add `pkg-config` to common system packages in `packages.nix`
- Fixes Ruby native extension build failures (psych, openssl gems) that rely on pkg-config to locate system libraries like libyaml and openssl

## Test plan
- [x] Verified `bundle update` succeeds after installing pkg-config
- [x] `nx check` passes
- [x] `nx up` applies cleanly