### PR TITLE
Move JS toolchain management from system packages to mise

### DIFF
--- a/nix/modules/home/mise.nix
+++ b/nix/modules/home/mise.nix
@@ -16,6 +16,7 @@
         python = "latest";
         ruby = "latest";
         node = "latest";
+        yarn = "latest";
         pnpm = "latest";
         rust = "latest";
       };

--- a/nix/modules/home/zsh.nix
+++ b/nix/modules/home/zsh.nix
@@ -103,8 +103,8 @@ in
 
       eval "$(pay-respects zsh --alias)"
 
-      # Initialize mise with lazy loading via shims for faster startup
-      eval "$(${pkgs.mise}/bin/mise activate zsh --shims)"
+      # Initialize mise (hooks into cd to set tool versions directly, avoiding shim overhead)
+      eval "$(${pkgs.mise}/bin/mise activate zsh)"
 
       # Initialize zoxide only in interactive shells
       if [[ $- == *i* ]]; then

--- a/nix/modules/system/packages.nix
+++ b/nix/modules/system/packages.nix
@@ -15,16 +15,13 @@ let
     lazygit
     markdownlint-cli
     mkalias
-    nodejs
     openssl
     pkg-config
-    pnpm
     rclone
     rsync
     shellcheck
     pay-respects
     watchman
-    yarn
     yq
     zellij
     zoxide


### PR DESCRIPTION
## Summary
- Remove `nodejs`, `pnpm`, and `yarn` from system packages (`packages.nix`) since they are already managed by mise
- Add `yarn` to mise tool definitions (`mise.nix`) alongside existing `node` and `pnpm` entries
- Switch mise from `--shims` mode to direct activation (`zsh.nix`) to fix starship prompt timeouts caused by shim overhead

## Test plan
- [x] `nx check` passes
- [x] `nx up` applies cleanly
- [x] `node`, `pnpm`, and `yarn` are available via mise after rebuild
- [x] Starship prompt no longer shows timeout warnings for node/ruby/python