### PR TITLE
Fix mise perf by removing yarn vfox backend, use corepack

### DIFF
--- a/nix/modules/home/mise.nix
+++ b/nix/modules/home/mise.nix
@@ -16,7 +16,6 @@
         python = "latest";
         ruby = "latest";
         node = "latest";
-        yarn = "latest";
         pnpm = "latest";
         rust = "latest";
       };

--- a/nix/modules/home/zsh.nix
+++ b/nix/modules/home/zsh.nix
@@ -103,8 +103,8 @@ in
 
       eval "$(pay-respects zsh --alias)"
 
-      # Initialize mise (hooks into cd to set tool versions directly, avoiding shim overhead)
-      eval "$(${pkgs.mise}/bin/mise activate zsh)"
+      # Initialize mise with shims for fast shell startup
+      eval "$(${pkgs.mise}/bin/mise activate zsh --shims)"
 
       # Initialize zoxide only in interactive shells
       if [[ $- == *i* ]]; then


### PR DESCRIPTION
## Summary
- Remove `yarn` from mise tools — its `vfox` backend added **~1.5s** to every mise invocation (hook-env, shim calls), causing starship prompt timeouts and slow shell startup
- Revert mise activation back to `--shims` mode now that shims are fast (~30ms) without the vfox overhead
- Yarn is still available via **corepack** (bundled with node), zero additional overhead

## Performance
| Metric | Before | After |
|--------|--------|-------|
| `mise hook-env` | 1.6s | 7ms |
| Shim calls (node/ruby/python) | ~1.5s each | ~30ms each |

## Test plan
- [x] `nx check` passes
- [x] `nx up` applies cleanly
- [x] `yarn --version` works (via corepack)
- [x] No starship timeout warnings in new shells