### PR TITLE
Add 1Password plugins.sh to mutable files management

### DIFF
--- a/bin/nx
+++ b/bin/nx
@@ -444,12 +444,13 @@ json_files_equal() {
 }
 # Must match mutablePaths in nix/modules/home/mutable-files.nix
 # Ordered list of shorthand names (used for iteration order)
-MANAGED_NAMES=(claude vscode vsmcp)
+MANAGED_NAMES=(claude op vscode vsmcp)
 BASELINE_DIR="$HOME/.local/share/nix-managed-baselines"
 
 # Shorthand -> full path mapping
 declare -A MANAGED_FILES=(
     [claude]=".claude/settings.json"
+    [op]=".config/op/plugins.sh"
     [vscode]="Library/Application Support/Code/User/settings.json"
     [vsmcp]="Library/Application Support/Code/User/mcp.json"
 )
@@ -457,6 +458,7 @@ declare -A MANAGED_FILES=(
 # Shorthand -> Nix source file mapping
 declare -A MANAGED_NIX_SOURCES=(
     [claude]="nix/modules/home/claude.nix"
+    [op]="nix/modules/home/onepassword.nix"
     [vscode]="nix/modules/home/vscode.nix"
     [vsmcp]="nix/modules/home/vscode.nix"
 )

--- a/completions/_nx
+++ b/completions/_nx
@@ -46,6 +46,7 @@ _nx() {
     local -a managed_names
     managed_names=(
         'claude:.claude/settings.json'
+        'op:.config/op/plugins.sh'
         'vscode:Library/Application Support/Code/User/settings.json'
         'vsmcp:Library/Application Support/Code/User/mcp.json'
         'all:All managed files'

--- a/nix/modules/home/mutable-files.nix
+++ b/nix/modules/home/mutable-files.nix
@@ -3,6 +3,7 @@
 let
   mutablePaths = [
     ".claude/settings.json"
+    ".config/op/plugins.sh"
     "Library/Application Support/Code/User/settings.json"
     "Library/Application Support/Code/User/mcp.json"
   ];


### PR DESCRIPTION
## Summary

- Add `.config/op/plugins.sh` to `mutablePaths` in `mutable-files.nix`
- Add `op` shorthand to `bin/nx` managed files mappings (path + Nix source)
- Add `op` to zsh completions in `completions/_nx`

This allows `nx managed` commands (status, diff, revert, apply) to work with the 1Password CLI plugin config alongside the existing Claude and VS Code entries.

## Test plan

- [x] `nx check` passes
- [x] `nx managed` shows `op` in the list
- [x] `nx m d op` diffs the 1Password plugins config