### PR TITLE
Add auto branch switching to nx pull command

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,7 @@ jobs:
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main
+          ENABLE_GITHUB_PULL_REQUEST_SUMMARY_COMMENT: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_BASH: true
           VALIDATE_MARKDOWN: true

--- a/bin/nx
+++ b/bin/nx
@@ -209,6 +209,21 @@ show_diff() {
 }
 
 pull_dotfiles() {
+    local default_branch
+    default_branch=$(get_default_branch)
+    local current_branch
+    current_branch=$(git -C "$DOTFILES_DIR" branch --show-current)
+
+    if [[ "$current_branch" != "$default_branch" ]]; then
+        log_info "Currently on branch '$current_branch', switching to '$default_branch'..."
+        if ! git -C "$DOTFILES_DIR" switch "$default_branch" 2>&1; then
+            log_error "Cannot switch to $default_branch (uncommitted changes would be overwritten)"
+            log_info "Commit or stash your changes first, then retry"
+            return 1
+        fi
+        log_success "Switched to $default_branch"
+    fi
+
     log_info "Pulling latest dotfiles from remote..."
     if git -C "$DOTFILES_DIR" pull; then
         log_success "Dotfiles updated successfully"


### PR DESCRIPTION
## Summary
- `nx p` now automatically switches to the default branch before pulling if currently on a different branch
- Uses `git switch` which fails cleanly if uncommitted changes would be overwritten
- Provides clear error messaging when the switch cannot be performed

## Test plan
- [x] Run `nx p` while on `main` — should pull as before with no switch attempt
- [x] Run `nx p` while on a feature branch with clean working tree — should switch to main and pull
- [x] Run `nx p` while on a feature branch with conflicting uncommitted changes — should fail with helpful message