### PR TITLE
Add rostrum CLI setup for work machine and fix minor issues

### DIFF
--- a/completions/_rostrum
+++ b/completions/_rostrum
@@ -1,0 +1,50 @@
+#compdef rostrum
+
+# Zsh completion for rostrum (Git worktree manager)
+
+_rostrum() {
+    local -a commands branches
+
+    commands=(
+        'init:Install rostrum by creating symlink in ~/.local/bin'
+        'update:Update rostrum to the latest version from git'
+        'setup:Creates a new Git worktree for the specified branch'
+        'create:Alias for setup'
+        'new:Alias for setup'
+        'add:Alias for setup'
+        'setup-db:Set up isolated database(s) for an existing worktree'
+        'teardown:Removes the Git worktree and cleans up'
+        'cleanup:Alias for teardown'
+        'remove:Alias for teardown'
+        'dev:Runs the webpack development server'
+        'list:List all active rostrum worktrees'
+        'ls:Alias for list'
+        'open:Opens the worktree in your configured editor'
+        'completion:Generate shell completion script'
+        'help:Show help information'
+    )
+
+    _arguments -C \
+        '1: :->command' \
+        '*::arg:->args'
+
+    case $state in
+        command)
+            _describe 'command' commands
+            ;;
+        args)
+            case $words[1] in
+                open|teardown|cleanup|remove|setup-db)
+                    branches=(${(f)"$(rostrum list 2>/dev/null | awk '{print $1}')"})
+                    _describe 'branch' branches
+                    ;;
+                completion)
+                    _values 'shell' 'bash' 'zsh'
+                    ;;
+            esac
+            ;;
+    esac
+}
+
+_rostrum "$@"
+compdef _rostrum rostrum

--- a/nix/modules/default.nix
+++ b/nix/modules/default.nix
@@ -70,6 +70,7 @@
     ./home/claude.nix
     ./home/ide-extensions.nix
     ./home/npmrc.nix
+    ./home/rostrum.nix
     ./home/mutable-files.nix
     ./home/ai-globals.nix
     ./home/tmux.nix

--- a/nix/modules/home/rostrum.nix
+++ b/nix/modules/home/rostrum.nix
@@ -1,0 +1,6 @@
+{ config, ... }:
+{
+  # Symlink rostrum CLI from local dev checkout
+  home.file.".local/bin/rostrum".source =
+    config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/dev/rostrum/bin/rostrum";
+}

--- a/nix/modules/home/vscode.nix
+++ b/nix/modules/home/vscode.nix
@@ -57,6 +57,7 @@ in
         "editor.formatOnPaste": true,
         "editor.rulers": [120],
         "terminal.integrated.fontFamily": "MesloLGS Nerd Font",
+        "mise.terminal.env": true,
         "git.enabledSmartCommit": true,
         "editor.stickyScroll.enabled": true,
         "[python]": { "editor.formatOnType": true },

--- a/nix/modules/system/system-defaults.nix
+++ b/nix/modules/system/system-defaults.nix
@@ -231,7 +231,7 @@ in
       end if
     end run
     FONTSCRIPT
-      su ${username} -c "osascript '$FONT_SCRIPT' '$TERMINAL_PLIST'" 2>/dev/null || true
+      su ${username} -c "osascript '$FONT_SCRIPT' '$TERMINAL_PLIST'" >/dev/null 2>&1 || true
       rm -f "$FONT_SCRIPT"
       echo "Terminal.app profile updated: font set to MesloLGS Nerd Font 11pt"
     fi


### PR DESCRIPTION
## Summary
- Add `rostrum.nix` Home Manager module (work machine only) that symlinks `~/.local/bin/rostrum` to the local dev checkout
- Add zsh completions for rostrum with dynamic branch completion for open/teardown/setup-db
- Enable `mise.terminal.env` in VS Code settings to fix Ruby version resolution in integrated terminals
- Suppress stray `true` output from osascript during Terminal.app font setup in activation script

## Test plan
- [x] `nx check` passes
- [x] `nx up -hm` applies cleanly on work machine
- [x] `rostrum` command works from any directory
- [x] Tab completion works for rostrum commands and branches
- [x] VS Code integrated terminal resolves correct Ruby version per project
- [x] `nx up` no longer prints bare `true` during activation