### PR TITLE
zsh autosuggest cleanup, ren completions + fixes, dv tasks dir

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ darwin-rebuild --rollback                 # Undo last change
 ## Gotchas
 
 - **`nix flake check` is slow**: Use `nix eval nix/#darwinConfigurations.X.system --apply 'x: "ok"'` for quick validation
+- **Atuin drives zsh-autosuggestions**: `atuin init zsh` sets `ZSH_AUTOSUGGEST_STRATEGY=(atuin)` (runs after `initContent`). If you want HISTFILE-driven inline suggestions, override via precmd hook — see `_fix_autosuggest_strategy` in `zsh.nix`
 - **Homebrew + Home Manager pattern**: Use `mkHomebrewWrapper` from `mcp-shared.nix` to install via Homebrew but keep Home Manager config (see `claude.nix`, `mise.nix`, `codex.nix`, `gemini.nix`)
 - **deadnix catches unused module args**: Don't add `lib` to module args unless it's actually used in the body — use `if/then/else` over `lib.optionalAttrs` when simpler
 - **Bootstrap mode**: `NIX_BOOTSTRAP_MODE=1` uses placeholder values; check `dotlib.getEnvOrFallback`

--- a/bin/dv
+++ b/bin/dv
@@ -480,6 +480,7 @@ typeset -gA SPECIAL_DIRS=(
     dotfiles "$HOME/dotfiles"
     dev "$HOME/dev"
     writing "$HOME/writing"
+    tasks "$HOME/tasks"
 )
 
 # Directories to scan for projects during indexing
@@ -487,6 +488,7 @@ typeset -ga PROJECT_PATHS=(
     "$HOME/dev"
     "$HOME/dev/git"
     "$HOME/writing"
+    "$HOME/tasks"
 )
 
 # Project name -> path mapping (populated by index_projects)

--- a/bin/ren
+++ b/bin/ren
@@ -154,8 +154,10 @@ interactive_game_selection() {
     echo "${game_map[$selection]}"
 }
 
-# Trim whitespace and expand tilde in path
-# Handles user input from prompts that may have leading/trailing whitespace
+# Trim whitespace, unquote shell escapes, and expand tilde in path
+# Handles user input from prompts that may contain shell-escaped paths (e.g.
+# drag-and-drop into the gum input produces "foo\ bar.zip" with literal
+# backslashes, since no shell is running to unescape them).
 # Usage: clean_path=$(trim_and_expand_path "$user_input")
 trim_and_expand_path() {
     local path="$1"
@@ -163,6 +165,8 @@ trim_and_expand_path() {
     path="${path#"${path%%[![:space:]]*}"}"
     # Trim trailing whitespace
     path="${path%"${path##*[![:space:]]}"}"
+    # Shell-dequote: "foo\ bar" → "foo bar", "'foo bar'" → "foo bar"
+    path="${(Q)path}"
     # Expand tilde to $HOME
     path="${path/#\~/$HOME}"
     echo "$path"

--- a/bin/ren
+++ b/bin/ren
@@ -420,10 +420,11 @@ startup_cleanup() {
 }
 
 # Get human-readable size
+# `du -sh` right-pads the size column, so lines like " 13G\t/path" have a
+# leading space. awk with default FS handles the leading whitespace correctly.
 get_size_human() {
     local path="$1"
-    local size_output=$(/usr/bin/du -sh "$path" 2>/dev/null)
-    echo "${size_output%%[[:space:]]*}"
+    /usr/bin/du -sh "$path" 2>/dev/null | /usr/bin/awk '{print $1}'
 }
 
 # Get relative time (e.g., "2 days ago")
@@ -758,6 +759,14 @@ cmd_install() {
     fi
 
     mv "$extracted_dir" "$install_path"
+
+    # Stamp mtime to now so `ren list`'s "installed" column reflects install
+    # time. Without this, Windows builds show the developer's packaging date:
+    # unar carries the zip's internal mtime onto the archive's root dir, and
+    # mv within the same filesystem preserves it. Mac .app bundles aren't
+    # usually affected since they're nested inside the zip's root, but we
+    # touch unconditionally for symmetry.
+    touch "$install_path"
 
     # Remove quarantine flag from Mac apps (macOS Gatekeeper security feature)
     if [[ "$platform" == "mac" ]]; then

--- a/bin/zsh-hist-clean
+++ b/bin/zsh-hist-clean
@@ -1,0 +1,133 @@
+#!/usr/bin/env zsh
+# zsh-hist-clean - Apply the zshaddhistory rewrite rules retroactively to
+# ~/.zsh_history so old noisy entries stop surfacing in zsh-autosuggestions.
+#
+# Mirrors the logic in nix/modules/home/zsh.nix. Safe by default:
+# dry-run prints a summary diff; pass --apply to rewrite in place with a
+# timestamped backup.
+#
+# Usage:
+#   zsh-hist-clean            # dry-run, show counts and sample diffs
+#   zsh-hist-clean --apply    # back up and rewrite ~/.zsh_history
+
+emulate -L zsh
+setopt pipefail no_unset
+
+HISTFILE_PATH=${HISTFILE:-$HOME/.zsh_history}
+APPLY=0
+[[ ${1:-} == --apply ]] && APPLY=1
+
+[[ -f $HISTFILE_PATH ]] || { print -u2 "not found: $HISTFILE_PATH"; exit 1; }
+
+# Shared classifier: _zhist_noisy + _zhist_classify. The interactive-shell
+# hook it also registers is a no-op here (sourced from a non-interactive zsh).
+source ${0:A:h}/../zsh/history.zsh
+
+# Split an extended-format line ": ts:dur;cmd" into prefix and cmd.
+# Plain lines get empty prefix.
+_zhist_split() {
+  local raw=$1
+  if [[ $raw == ': '[0-9]*':'[0-9]*';'* ]]; then
+    local prefix=${raw%%;*}';'
+    local cmd=${raw#*;}
+    print -r -- "$prefix"
+    print -r -- "$cmd"
+  else
+    print -r -- ""
+    print -r -- "$raw"
+  fi
+}
+
+tmpfile=$(mktemp "${TMPDIR:-/tmp}/zsh-hist-clean.XXXXXX")
+trap 'rm -f $tmpfile' EXIT
+
+typeset -i total=0 kept=0 rewritten_count=0 dropped=0 skipped_multiline=0
+typeset -a sample_rewrites sample_drops
+
+# Main processing wrapped in a function so `local` declarations are scoped
+# correctly. At script top-level, `local NAME` is `typeset NAME` which PRINTS
+# the current value of NAME — that would leak variable state into the tmpfile.
+_zhist_process() {
+  local acc="" line complete split prefix cmd verdict new
+  while IFS= read -r line || [[ -n $line ]]; do
+    if [[ -n $acc ]]; then
+      acc+=$'\n'$line
+    else
+      acc=$line
+    fi
+    # continuation if line ends in a single trailing backslash
+    if [[ $line == *\\ && $line != *\\\\ ]]; then
+      continue
+    fi
+    complete=$acc
+    acc=""
+    (( total++ ))
+
+    # Skip (preserve as-is) any multi-line entry.
+    if [[ $complete == *$'\n'* ]]; then
+      (( skipped_multiline++ ))
+      print -r -- "$complete"
+      continue
+    fi
+
+    split=$(_zhist_split "$complete")
+    prefix=${split%%$'\n'*}
+    cmd=${split#*$'\n'}
+
+    _zhist_classify "$cmd"
+    verdict=$REPLY
+    case $verdict in
+      KEEP)
+        (( kept++ ))
+        print -r -- "$complete"
+        ;;
+      DROP)
+        (( dropped++ ))
+        (( ${#sample_drops} < 5 )) && sample_drops+=("$cmd")
+        ;;
+      REWRITE*)
+        new=${verdict#REWRITE	}
+        (( rewritten_count++ ))
+        (( ${#sample_rewrites} < 10 )) && sample_rewrites+=("$cmd  ==>  $new")
+        print -r -- "${prefix}${new}"
+        ;;
+    esac
+  done
+  # Trailing incomplete accumulation (shouldn't happen on a valid histfile)
+  if [[ -n $acc ]]; then
+    (( total++, kept++ ))
+    print -r -- "$acc"
+  fi
+}
+
+_zhist_process < $HISTFILE_PATH > $tmpfile
+
+print "Total entries:       $total"
+print "Kept unchanged:      $kept"
+print "Rewritten:           $rewritten_count"
+print "Dropped (cd):        $dropped"
+print "Multi-line skipped:  $skipped_multiline"
+
+if (( ${#sample_rewrites} > 0 )); then
+  print
+  print "Sample rewrites:"
+  printf '  %s\n' "${sample_rewrites[@]}"
+fi
+if (( ${#sample_drops} > 0 )); then
+  print
+  print "Sample drops:"
+  printf '  %s\n' "${sample_drops[@]}"
+fi
+
+if (( APPLY )); then
+  backup=$HISTFILE_PATH.bak.$(date +%Y%m%d-%H%M%S)
+  cp $HISTFILE_PATH $backup
+  mv $tmpfile $HISTFILE_PATH
+  trap - EXIT
+  print
+  print "Applied. Backup: $backup"
+  print "Close all other zsh sessions and reopen to pick up changes."
+else
+  print
+  print "Dry run. Pass --apply to rewrite $HISTFILE_PATH (backup created automatically)."
+fi

--- a/completions/_dv
+++ b/completions/_dv
@@ -17,6 +17,7 @@ _dv() {
         'dotfiles'
         'dev'
         'writing'
+        'tasks'
     )
 
     # Function to get all project names
@@ -27,6 +28,7 @@ _dv() {
             "$HOME/dev"
             "$HOME/dev/git"
             "$HOME/writing"
+            "$HOME/tasks"
         )
 
         # Add special directories

--- a/completions/_ren
+++ b/completions/_ren
@@ -1,0 +1,86 @@
+#compdef ren
+
+# Zsh completion for ren (Ren'Py game manager)
+
+_ren() {
+    local -a commands
+    commands=(
+        'install:Install a game from archive'
+        'launch:Launch an installed game'
+        'list:List all installed games'
+        'cleanup:Clean up temporary files or games'
+        'mod:Install a mod into an existing game'
+        'help:Show help'
+    )
+
+    # Collect installed game base names (version/extension stripped).
+    # Mirrors the grouping logic in build_game_selection_list.
+    _ren_games() {
+        setopt localoptions null_glob
+        local games_dir="${REN_GAMES_DIR:-$HOME/renpy-games}"
+        [[ -d $games_dir ]] || return 1
+
+        local -a names
+        local item name base
+        for item in "$games_dir"/*; do
+            [[ -d $item ]] || continue
+            name=${item:t}
+            name=${name%.app}
+            base=${name%-[0-9]*}
+            names+=("$base")
+        done
+        names=(${(u)${(o)names}})
+        compadd -a names
+    }
+
+    _ren_cleanup_targets() {
+        local -a targets=(
+            'tmp:Remove temporary extraction directories'
+            'games:Interactive removal of installed games'
+        )
+        _describe 'target' targets
+    }
+
+    _ren_help_topics() {
+        local -a topics=(install launch list cleanup mod)
+        compadd -a topics
+    }
+
+    _ren_archives() {
+        _files -g '*.(zip|7z|rar|tar|tar.gz|tgz|tar.bz2|tbz|tbz2|tar.xz|txz)'
+    }
+
+    if (( CURRENT == 2 )); then
+        _describe 'command' commands
+        return
+    fi
+
+    case "$words[2]" in
+        launch|l|play|p)
+            (( CURRENT == 3 )) && _ren_games
+            ;;
+        mod|m)
+            if (( CURRENT == 3 )); then
+                _ren_games
+            elif (( CURRENT == 4 )); then
+                _ren_archives
+            fi
+            ;;
+        install|i)
+            # ren install [-w|-m|-f] <archive>
+            _arguments \
+                '(-w --windows)'{-w,--windows}'[Windows build]' \
+                '(-m --mac)'{-m,--mac}'[Mac build]' \
+                '(-f --force)'{-f,--force}'[Overwrite existing]' \
+                '*:archive:_ren_archives'
+            ;;
+        cleanup|clean)
+            (( CURRENT == 3 )) && _ren_cleanup_targets
+            ;;
+        help|h)
+            (( CURRENT == 3 )) && _ren_help_topics
+            ;;
+    esac
+}
+
+_ren "$@"

--- a/nix/modules/home/zsh.nix
+++ b/nix/modules/home/zsh.nix
@@ -82,14 +82,17 @@ in
       bindkey '^[w' kill-region
 
       # History
-      HISTDUP=erase
       setopt appendhistory
       setopt sharehistory
       setopt hist_ignore_space
       setopt hist_ignore_all_dups
       setopt hist_save_no_dups
-      setopt hist_ignore_dups
       setopt hist_find_no_dups
+
+      # Suggestion filtering: strip one-off args from saved history and keep
+      # zsh-autosuggestions reading from $history (not atuin). See comments in
+      # the sourced file.
+      source ${config.home.homeDirectory}/dotfiles/zsh/history.zsh
 
       # Completion styling
       zstyle ':completion:*' matcher-list 'm:{a-z}={A-Za-z}'

--- a/zsh/history.zsh
+++ b/zsh/history.zsh
@@ -72,6 +72,15 @@ if [[ -o interactive ]]; then
   _zsh_autosuggest_strategy_clean_history() {
     emulate -L zsh
     setopt EXTENDED_GLOB
+
+    # For commands whose args come from a well-defined set (project names,
+    # game names, subcommands), defer to the `completion` strategy later in
+    # the chain — it enumerates all valid options rather than biasing toward
+    # whatever was last used.
+    case "$1" in
+      'dv '*|'ren '*) return ;;
+    esac
+
     # Escape glob metacharacters in the typed prefix so it's matched literally.
     local prefix=${1//(#m)[\\()\[\]|*?~^]/\\$MATCH}
     # ${history[@]} iterates values newest-first. Indexing via numeric keys
@@ -87,8 +96,11 @@ if [[ -o interactive ]]; then
 
   # atuin init (runs later in .zshrc) sets strategy to (atuin). Override on
   # first prompt so our strategy wins. Atuin still owns Ctrl+R.
+  # Strategy chain: filtered history first (fast), then zsh's completion
+  # system as fallback (so e.g. `dv cd dat` suggests `dating_apps` from the
+  # _dv completion even on a fresh command).
   _fix_autosuggest_strategy() {
-    ZSH_AUTOSUGGEST_STRATEGY=(clean_history)
+    ZSH_AUTOSUGGEST_STRATEGY=(clean_history completion)
     add-zsh-hook -d precmd _fix_autosuggest_strategy
   }
   add-zsh-hook precmd _fix_autosuggest_strategy

--- a/zsh/history.zsh
+++ b/zsh/history.zsh
@@ -1,0 +1,111 @@
+# Shared history-suggestion logic. Sourced from:
+#   - nix/modules/home/zsh.nix   (installs live hook + autosuggest strategy)
+#   - bin/zsh-hist-clean         (retroactive cleanup of ~/.zsh_history)
+#
+# Goals:
+#   - Suggestions skip one-off command lines (paths, prompts, commit messages).
+#   - HISTFILE stays clean so new sessions load already-filtered history.
+#   - Atuin continues to own Ctrl+R and keeps full originals for search.
+
+# ---- Classifier ------------------------------------------------------------
+# Return 0 if a token looks like a throwaway arg (path, quoted blob, URL,
+# opaque long string). Return 1 otherwise.
+_zhist_noisy() {
+  local t=$1
+  [[ $t == \"*\" || $t == \'*\' ]] && return 0
+  [[ $t == http://* || $t == https://* || $t == git@*:* ]] && return 0
+  local slashes=${t//[^\/]/}
+  (( ${#slashes} >= 4 )) && return 0
+  (( ${#t} > 40 )) && return 0
+  return 1
+}
+
+# Classify a command line. Sets global REPLY to one of:
+#   KEEP                — line is fine to keep/suggest
+#   DROP                — discard entirely (e.g. cd; zoxide owns these)
+#   REWRITE<TAB><new>   — replace with <new>
+# Uses REPLY instead of stdout so callers can avoid command-substitution
+# subshells on hot paths (autosuggest strategy runs per keystroke).
+_zhist_classify() {
+  emulate -L zsh
+  REPLY=KEEP
+  local line=${1%%$'\n'}
+  [[ $line == *[\|\&\;\<\>]* ]] && return
+  local -a parts=(${(z)line})
+  (( ${#parts} < 2 )) && return
+
+  local cmd=$parts[1]
+  local rewritten=""
+  case $cmd in
+    cd) REPLY=DROP; return ;;
+    rm)
+      local kept="rm" p
+      for p in ${parts[2,-1]}; do
+        [[ $p == -* ]] && kept+=" $p" || break
+      done
+      rewritten=$kept
+      ;;
+    ren|claude|open|git|g)
+      local kept=$cmd p
+      for p in ${parts[2,-1]}; do
+        if _zhist_noisy $p; then break; fi
+        kept+=" $p"
+      done
+      rewritten=$kept
+      ;;
+    *) return ;;
+  esac
+
+  if [[ -n $rewritten && $rewritten != $line ]]; then
+    REPLY="REWRITE	$rewritten"
+  fi
+}
+
+# ---- Live integration (interactive shells only) ----------------------------
+if [[ -o interactive ]]; then
+  autoload -Uz add-zsh-hook
+
+  # Custom autosuggestions strategy: walk $history newest→oldest, return the
+  # first entry that (a) has the typed prefix and (b) the classifier says
+  # is clean (KEEP). This bypasses any $history pollution from zshaddhistory
+  # return-code quirks and makes suggestions authoritative via the classifier.
+  _zsh_autosuggest_strategy_clean_history() {
+    emulate -L zsh
+    setopt EXTENDED_GLOB
+    # Escape glob metacharacters in the typed prefix so it's matched literally.
+    local prefix=${1//(#m)[\\()\[\]|*?~^]/\\$MATCH}
+    # ${history[@]} iterates values newest-first. Indexing via numeric keys
+    # would be wrong — $history is an associative array keyed by event number,
+    # and those keys don't start at 1.
+    local entry
+    for entry in "${history[@]}"; do
+      [[ $entry == $~prefix* ]] || continue
+      _zhist_classify "$entry"
+      [[ $REPLY == KEEP ]] && { typeset -g suggestion=$entry; return }
+    done
+  }
+
+  # atuin init (runs later in .zshrc) sets strategy to (atuin). Override on
+  # first prompt so our strategy wins. Atuin still owns Ctrl+R.
+  _fix_autosuggest_strategy() {
+    ZSH_AUTOSUGGEST_STRATEGY=(clean_history)
+    add-zsh-hook -d precmd _fix_autosuggest_strategy
+  }
+  add-zsh-hook precmd _fix_autosuggest_strategy
+
+  # zshaddhistory: primarily keeps HISTFILE clean. Even if $history retains
+  # the original in memory due to zsh's return-code semantics, the custom
+  # strategy above filters suggestions by classifier — so visible behavior is
+  # correct regardless.
+  zshaddhistory() {
+    _zhist_classify "$1"
+    case $REPLY in
+      DROP) return 1 ;;
+      REWRITE*)
+        print -sr -- ${REPLY#REWRITE	}
+        return 1
+        ;;
+      *) return 0 ;;
+    esac
+  }
+fi


### PR DESCRIPTION
Several related shell-ergonomics fixes bundled together.

## zsh autosuggestions: filter + completion chain

Inline autosuggestions no longer replay command lines whose args are always throwaway (download paths, quoted prompts, commit messages). Atuin still owns Ctrl+R and retains full originals.

Driven by a shared classifier in [zsh/history.zsh](zsh/history.zsh):

- `zshaddhistory` hook strips noisy tails before saving, keeping HISTFILE clean.
- Custom `_zsh_autosuggest_strategy_clean_history` walks `$history` at suggestion time and skips entries the classifier rejects.
- Strategy chain is `(clean_history completion)` — filtered history first, falling back to zsh's built-in completion strategy for fresh commands.
- For commands with well-defined arg sets (`dv *`, `ren *`), `clean_history` short-circuits so the completion strategy drives the suggestion instead of biasing toward whatever was last used.
- `precmd` override resets `ZSH_AUTOSUGGEST_STRATEGY` after atuin init (which otherwise hijacks it to `(atuin)`).

Retroactive cleanup at [bin/zsh-hist-clean](bin/zsh-hist-clean) reuses the classifier (dry-run default, `--apply` to rewrite with backup).

Drive-bys: removed pre-existing no-ops in [zsh.nix](nix/modules/home/zsh.nix) (`HISTDUP=erase` is a bash-ism, `hist_ignore_dups` is redundant with `hist_ignore_all_dups`). Documented the atuin hijack in [CLAUDE.md](CLAUDE.md) Gotchas.

## `ren` fixes and completions

- **SIZE column blank for ≥10G games**: `du -sh` right-pads sizes, so 2-digit values come through as ` 13G\t/path`. The old parser split on the leading space and returned empty. Switched to `/usr/bin/awk '{print $1}'`.
- **INSTALLED column showed packaging date for Windows builds**: `unar` stamps the zip's internal mtime onto the archive's root dir, and `mv` preserves it. `touch` the install path after the move.
- **`ren mod` interactive prompt couldn't find paths with spaces**: drag-and-dropping a path into gum's input field produced literal backslashes (no shell was running to unescape). `trim_and_expand_path` now shell-dequotes via `${(Q)}`.
- **New [completions/_ren](completions/_ren)**: subcommands, installed game names for `launch`/`mod`, archive files for `install`, and `tmp|games` targets for `cleanup`.

## `dv`: add `~/tasks`

[bin/dv](bin/dv) and [completions/_dv](completions/_dv) now treat `tasks` as a special shortcut (`dv cd tasks`) and index its immediate subdirs for project-name completion.

## Test plan

- [x] `nx check` / `nix eval` passes
- [x] Classifier unit tests pass
- [x] Live shell: `echo $ZSH_AUTOSUGGEST_STRATEGY` prints `clean_history completion`
- [x] Typing `ren ` suggests a clean entry, not a full download path
- [x] Typing `dv cd dat` suggests `dating_apps` via completion (not from history)
- [x] `zsh-hist-clean` dry-run reports sensible counts
- [x] `ren list` shows sizes for 10G+ games
- [x] `ren list` INSTALLED column reflects install time (new Summer-Crush `touch`ed to verify)
- [x] `ren mod <game>` interactive prompt handles drag-and-dropped paths with escaped spaces
- [x] `_ren` completion offers all 6 installed game base names
- [x] `dv cd tasks` jumps correctly; `dv cd <TAB>` shows projects under `~/tasks`
- [x] Monitor for typing latency regressions from the completion fallback