### PR TITLE
Fix ren commands silently breaking PATH via `local path=`

### DIFF
--- a/bin/ren
+++ b/bin/ren
@@ -89,14 +89,17 @@ normalize_basename() {
 }
 
 # Resolve symlink or return path as-is
-# Provides consistent symlink handling throughout the script
+# Provides consistent symlink handling throughout the script.
+# NOTE: Don't name the local variable `path` — zsh ties `$path` (array) to
+# `$PATH` (scalar), so `local path=...` shadows PATH inside the function
+# and breaks command lookup (e.g. readlink, awk not found).
 # Usage: resolve_symlink_or_echo <path>
 resolve_symlink_or_echo() {
-    local path="$1"
-    if [[ -L "$path" ]]; then
-        readlink -f "$path"
+    local target="$1"
+    if [[ -L "$target" ]]; then
+        readlink -f "$target"
     else
-        echo "$path"
+        echo "$target"
     fi
 }
 
@@ -160,16 +163,17 @@ interactive_game_selection() {
 # backslashes, since no shell is running to unescape them).
 # Usage: clean_path=$(trim_and_expand_path "$user_input")
 trim_and_expand_path() {
-    local path="$1"
+    # `p` not `path` — see note on resolve_symlink_or_echo re: shadowing $PATH.
+    local p="$1"
     # Trim leading whitespace
-    path="${path#"${path%%[![:space:]]*}"}"
+    p="${p#"${p%%[![:space:]]*}"}"
     # Trim trailing whitespace
-    path="${path%"${path##*[![:space:]]}"}"
+    p="${p%"${p##*[![:space:]]}"}"
     # Shell-dequote: "foo\ bar" → "foo bar", "'foo bar'" → "foo bar"
-    path="${(Q)path}"
+    p="${(Q)p}"
     # Expand tilde to $HOME
-    path="${path/#\~/$HOME}"
-    echo "$path"
+    p="${p/#\~/$HOME}"
+    echo "$p"
 }
 
 # Validate Ren'Py SDK installation
@@ -427,8 +431,9 @@ startup_cleanup() {
 # `du -sh` right-pads the size column, so lines like " 13G\t/path" have a
 # leading space. awk with default FS handles the leading whitespace correctly.
 get_size_human() {
-    local path="$1"
-    /usr/bin/du -sh "$path" 2>/dev/null | /usr/bin/awk '{print $1}'
+    # `target` not `path` — see resolve_symlink_or_echo note on $PATH shadowing.
+    local target="$1"
+    /usr/bin/du -sh "$target" 2>/dev/null | /usr/bin/awk '{print $1}'
 }
 
 # Get relative time (e.g., "2 days ago")
@@ -713,15 +718,15 @@ cmd_install() {
         log_info "Found existing installation(s):"
         for ver_path in "${existing_versions[@]}"; do
             local ver="${ver_path%%:*}"
-            local path="${ver_path#*:}"
-            echo "  - Version $ver: $(basename "$path")"
+            local ver_dir="${ver_path#*:}"
+            echo "  - Version $ver: $(basename "$ver_dir")"
         done
 
         if gum_clean confirm "Remove old version(s) before installing?"; then
             for ver_path in "${existing_versions[@]}"; do
-                local path="${ver_path#*:}"
-                log_info "Removing: $(basename "$path")"
-                rm -rf "$path"
+                local ver_dir="${ver_path#*:}"
+                log_info "Removing: $(basename "$ver_dir")"
+                rm -rf "$ver_dir"
             done
 
             # Remove symlink if it exists


### PR DESCRIPTION
## Summary

`local path="$1"` in zsh shadows the special `$path` array that's tied to `$PATH`, so inside those functions `PATH` becomes literally the argument string (e.g. a game name), and every external command lookup fails with "command not found".

Surfaced on `ren mod <game> <path>`: `resolve_symlink_or_echo` set PATH to the game name, `readlink` wasn't on it, the symlink didn't resolve, and the failure surfaced as `Game not found: Straitened-Times` preceded by a `readlink: command not found` error.

Renamed 5 occurrences of `local path=` across `resolve_symlink_or_echo`, `trim_and_expand_path`, `get_size_human`, and the two loops in `cmd_install`. Added a comment on `resolve_symlink_or_echo` noting the trap so we don't reintroduce it.

## Test plan

- [x] `zsh -n bin/ren` passes
- [x] `resolve_symlink_or_echo resolves the symlink (previously failed when called through `find_game_dir` with a stale PATH)