### PR TITLE
Fix compinit error from stale zinit symlinks after Nix GC

### DIFF
--- a/nix/modules/home/zsh.nix
+++ b/nix/modules/home/zsh.nix
@@ -14,6 +14,12 @@ in
     enable = true;
 
     initContent = ''
+      # Fix stale zinit symlinks after Nix store GC or package upgrades
+      if [[ -L "$HOME/.local/share/zinit/plugins/_local---zinit/_zinit" ]] && \
+         ! [[ -e "$HOME/.local/share/zinit/plugins/_local---zinit/_zinit" ]]; then
+        rm -rf "$HOME/.local/share/zinit/plugins/_local---zinit"
+      fi
+
       # Load zinit
       source ${pkgs.zinit}/share/zinit/zinit.zsh
 


### PR DESCRIPTION
## Summary

- Adds a guard before zinit loads that detects dangling `_local---zinit` symlinks and removes the stale directory so zinit recreates it cleanly
- Fixes the intermittent `compinit:527: no such file or directory` error on new terminal sessions

## Root cause

After `nix store gc` or a zinit package upgrade, `~/.local/share/zinit/plugins/_local---zinit/_zinit` still points to the old Nix store path. On days when `compinit` does a full rescan (compdump older than 1 day), it follows the dangling symlink and errors. On cached days (`compinit -C`), the error is skipped — which is why it's intermittent.

## Test plan

- [x] `nx check` passes
- [x] `nx up` applies cleanly
- [x] New terminal opens without compinit errors
- [x] `zinit` commands still work normally