### PR TITLE
Tune Claude/VS Code defaults and unify activation output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ dotfiles/
 - `zsh.nix` - Shell config with zinit plugin management
 - `mutable-files.nix` - Writable copies of app config files with conflict detection
 - `modern-cli-tools.nix` - bat, eza, ripgrep, fd, atuin, etc.
+- `ide-extensions.nix` - VS Code extension list; work-only extensions go in `workOnlyExtensions` (gated by `isWorkMachine`)
 
 ## Adding a New Module
 
@@ -90,3 +91,4 @@ darwin-rebuild --rollback                 # Undo last change
 - **New Nix files must be `git add`ed before eval**: Nix flakes only see git-tracked files — `nix eval` will error on untracked `.nix` files
 - **delta is the git pager**: `git diff --no-index` pipes through delta; use `git -c core.pager= diff` to bypass
 - **deadnix warnings**: Remove unused `let` bindings - deadnix (part of `nx lint`) fails on dead code
+- **Activation-script output style**: User-facing `echo` in activation scripts (`nix/modules/**`) uses inline ANSI — `\033[0;34mℹ\033[0m` info, `\033[0;32m✓\033[0m` success, `\033[1;33m!\033[0m` warning, `\033[0;31m✗\033[0m` error. Can't source `bin/shared` here. See `ruby.nix`, `mutable-files.nix`, `system-defaults.nix` for examples.

--- a/bin/nx
+++ b/bin/nx
@@ -591,20 +591,25 @@ managed_revert() {
         return 1
     fi
 
+    local total=${#RESOLVED_NAMES[@]}
+    local reverted=0
+
     for name in "${RESOLVED_NAMES[@]}"; do
         local path="${MANAGED_FILES[$name]}"
         local target="$HOME/$path"
         local baseline="$BASELINE_DIR/$path"
 
         if [ ! -f "$baseline" ]; then
-            log_error "No baseline for $name: $path"
+            log_error "Failed to revert ${name} (${path}): no baseline"
             continue
         fi
 
         cp "$baseline" "$target"
         chmod 644 "$target"
-        log_success "Reverted to Nix version for: ${name} ($path)"
+        reverted=$((reverted + 1))
     done
+
+    log_success "Reverted ${reverted}/${total} managed files to Nix baseline"
 }
 
 managed_apply() {

--- a/nix/modules/home/claude.nix
+++ b/nix/modules/home/claude.nix
@@ -420,6 +420,7 @@ in
     settings = {
       respectGitignore = false;
       skipAllowlistPrompt = true;
+      skipAutoPermissionPrompt = true;
       cleanupPeriodDays = 20;
       includeCoAuthoredBy = false;
       model = "opus[1m]";
@@ -531,7 +532,7 @@ in
           ++ slackAiMcpAskTools
           ++ snowflakeAiMcpAskTools
         ));
-        defaultMode = "auto";
+        defaultMode = "acceptEdits";
         additionalDirectories = [];
       };
       statusLine = {

--- a/nix/modules/home/ide-extensions.nix
+++ b/nix/modules/home/ide-extensions.nix
@@ -1,7 +1,16 @@
-{ lib, pkgs, ... }:
+{ lib, pkgs, isWorkMachine ? false, ... }:
 
 let
-  extensions = [
+  workOnlyExtensions = [
+    "circleci.circleci"
+    "launchdarklyofficial.launchdarkly"
+    "ms-python.black-formatter"
+    "noku.rails-run-spec-vscode"
+    "soutaro.steep-vscode"
+    "sporto.rails-go-to-spec"
+    "ziyasal.vscode-open-in-github"
+  ];
+  extensions = (lib.optionals isWorkMachine workOnlyExtensions) ++ [
     "alefragnani.project-manager"
     "alexcvzz.vscode-sqlite"
     "aliariff.auto-add-brackets"
@@ -51,6 +60,7 @@ let
     "shopify.ruby-extensions-pack"
     "shopify.ruby-lsp"
     "sorbet.sorbet-vscode-extension"
+    "soutaro.rbs-syntax"
     "stylelint.vscode-stylelint"
     "tamasfe.even-better-toml"
     "tomoki1207.pdf"

--- a/nix/modules/home/mutable-files.nix
+++ b/nix/modules/home/mutable-files.nix
@@ -40,7 +40,7 @@ in
         rm "$target"
         install -m 644 "$store_path" "$target"
         install -m 644 "$store_path" "$baseline"
-        echo "mutable-files: converted symlink to writable copy: $rel_path"
+        echo -e "\033[0;32m✓\033[0m Converted symlink to writable copy: $rel_path"
         return
       fi
 
@@ -48,7 +48,7 @@ in
       if [ ! -f "$target" ]; then
         install -m 644 "$store_path" "$target"
         install -m 644 "$store_path" "$baseline"
-        echo "mutable-files: created writable copy: $rel_path"
+        echo -e "\033[0;32m✓\033[0m Created writable copy: $rel_path"
         return
       fi
 
@@ -62,7 +62,7 @@ in
       if [ -f "$baseline" ] && cmp -s "$target" "$baseline"; then
         install -m 644 "$store_path" "$target"
         install -m 644 "$store_path" "$baseline"
-        echo "mutable-files: updated writable copy: $rel_path"
+        echo -e "\033[0;32m✓\033[0m Updated writable copy: $rel_path"
         return
       fi
 

--- a/nix/modules/home/ruby.nix
+++ b/nix/modules/home/ruby.nix
@@ -14,20 +14,20 @@ in
       installRubyVersions = lib.hm.dag.entryAfter ["writeBoundary"] ''
         export PATH="${pkgs.mise}/bin:$PATH:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 
-        echo -e "\033[34mVerifying Ruby installations...\033[0m"
+        echo -e "\033[0;34mℹ\033[0m Verifying Ruby installations..."
         for version in ${lib.escapeShellArgs rubyVersions}; do
           if [ -d "$HOME/.local/share/mise/installs/ruby/$version" ]; then
-            echo -e "\033[32mRuby $version installation verified\033[0m"
+            echo -e "\033[0;32m✓\033[0m Ruby $version installation verified"
           else
-            echo -e "\033[33mInstalling Ruby $version...\033[0m"
+            echo -e "\033[1;33m!\033[0m Installing Ruby $version..."
             if ! mise install ruby@$version; then
-              echo -e "\033[31mFailed to install Ruby $version\033[0m"
+              echo -e "\033[0;31m✗\033[0m Failed to install Ruby $version"
               exit 1
             fi
-            echo -e "\033[32mRuby $version installation completed\033[0m"
+            echo -e "\033[0;32m✓\033[0m Ruby $version installation completed"
           fi
         done
-        echo -e "\033[34mFinished Ruby versions verification/installation\033[0m"
+        echo -e "\033[0;34mℹ\033[0m Finished Ruby versions verification/installation"
       '';
     };
 

--- a/nix/modules/home/vscode.nix
+++ b/nix/modules/home/vscode.nix
@@ -93,6 +93,7 @@ in
         "github.copilot.editor.enableAutoCompletions": true,
         "editor.wordWrap": "on",
         "workbench.activityBar.orientation": "vertical",
+        "workbench.secondarySideBar.defaultVisibility": "hidden",
         "editor.fontFamily": "Menlo, Monaco, 'Courier New', monospace, MesloLGS Nerd Font ",
         "rubyLsp.rubyVersionManager": { "identifier": "mise", "path": "${homeDirectory}/.local/bin/mise" },
         "diffEditor.ignoreTrimWhitespace": false,

--- a/nix/modules/system/system-defaults.nix
+++ b/nix/modules/system/system-defaults.nix
@@ -148,12 +148,12 @@ in
 
   # Create a dock setup script that runs as the user
   system.activationScripts.extraActivation.text = ''
-    echo "Creating dock setup script"
+    echo -e "\033[0;34mℹ\033[0m Creating dock setup script"
 
     # Create the script with the actual paths expanded
     cat > /usr/local/bin/setup-dock << 'SCRIPT_END'
     #!/bin/bash
-    echo "Setting up dock for user $(whoami)"
+    echo -e "\033[0;34mℹ\033[0m Setting up dock for user $(whoami)"
 
     # Optimized dock setup - batch operation
     ${dockSetupCommand}
@@ -184,7 +184,7 @@ in
 
     # Restart Dock to apply changes
     killall Dock 2>/dev/null || true
-    echo "Dock setup complete with all ${username}'s apps!"
+    echo -e "\033[0;32m✓\033[0m Dock setup complete with all ${username}'s apps!"
     SCRIPT_END
 
     # Make script executable
@@ -193,15 +193,15 @@ in
     # Run the script as the user
     su ${username} -c "/usr/local/bin/setup-dock"
 
-    echo "Dock setup script created and executed"
-    echo "You can re-run it anytime with: setup-dock"
+    echo -e "\033[0;32m✓\033[0m Dock setup script created and executed"
+    echo -e "\033[0;34mℹ\033[0m You can re-run it anytime with: setup-dock"
 
     # iTerm2: Set profile defaults
     ITERM_PLIST="${homeDirectory}/Library/Preferences/com.googlecode.iterm2.plist"
     if [ -f "$ITERM_PLIST" ]; then
       su ${username} -c "/usr/libexec/PlistBuddy -c \"Set ':New Bookmarks:0:Custom Directory' Recycle\" '$ITERM_PLIST'" 2>/dev/null || true
       su ${username} -c "/usr/libexec/PlistBuddy -c \"Set ':New Bookmarks:0:Normal Font' MesloLGSNFM-Regular\ 11\" '$ITERM_PLIST'" 2>/dev/null || true
-      echo "iTerm2 profile updated: font and directory settings"
+      echo -e "\033[0;32m✓\033[0m iTerm2 profile updated: font and directory settings"
     fi
 
     # Terminal.app: Set font to MesloLGS Nerd Font 11pt
@@ -233,11 +233,11 @@ in
     FONTSCRIPT
       su ${username} -c "osascript '$FONT_SCRIPT' '$TERMINAL_PLIST'" >/dev/null 2>&1 || true
       rm -f "$FONT_SCRIPT"
-      echo "Terminal.app profile updated: font set to MesloLGS Nerd Font 11pt"
+      echo -e "\033[0;32m✓\033[0m Terminal.app profile updated: font set to MesloLGS Nerd Font 11pt"
     fi
 
     # Force reload of preference cache to apply natural scrolling setting
-    echo "Reloading trackpad preferences..."
+    echo -e "\033[0;34mℹ\033[0m Reloading trackpad preferences..."
     killall cfprefsd 2>/dev/null || true
   '';
 }


### PR DESCRIPTION
## Summary

**Claude Code**
- Revert `defaultMode` from `auto` back to `acceptEdits`
- Add `skipAutoPermissionPrompt` to settings

**VS Code**
- Hide secondary sidebar by default (`workbench.secondarySideBar.defaultVisibility: hidden`)
- Introduce work-only extension list gated by `isWorkMachine`: CircleCI, LaunchDarkly, Rails Go to Spec, Rails Run Specs, Steep, Black Formatter, Open in GitHub
- Add `soutaro.rbs-syntax` to the shared extension list

**Activation-script output**
- Unify user-facing output with an ANSI convention: blue `ℹ` info, green `✓` success, yellow `!` warning, red `✗` error
- Apply to `ruby.nix`, `mutable-files.nix`, and `system-defaults.nix`

**`nx` tooling**
- `nx up -fm` / `nx m r` now summarize revert output as `N/M` instead of one line per file; still prints explicit errors when a baseline is missing

**Docs**
- Document the output convention and `ide-extensions.nix` work-only split in `CLAUDE.md`

## Test plan

- [x] `nx check` passes
- [x] `nx diff` preview matches expectations
- [x] `nx up -hm` applies cleanly on personal machine
- [x] `nx up -hm` applies cleanly on work machine and installs the work-only extensions
- [x] Claude Code opens without defaulting to auto mode
- [x] VS Code starts with the secondary sidebar hidden
- [x] `nx up -fm` prints a single `Reverted N/M …` summary line
- [x] Ruby/mutable-files/dock activation output uses the new `ℹ`/`✓` style