### PR TITLE
Switch Claude Code default permission mode back to auto

### DIFF
--- a/nix/modules/home/claude.nix
+++ b/nix/modules/home/claude.nix
@@ -532,7 +532,7 @@ in
           ++ slackAiMcpAskTools
           ++ snowflakeAiMcpAskTools
         ));
-        defaultMode = "acceptEdits";
+        defaultMode = "auto";
         additionalDirectories = [];
       };
       statusLine = {


### PR DESCRIPTION
## Summary
- Revert `defaultMode` in `nix/modules/home/claude.nix` from `acceptEdits` back to `auto` so Claude Code launches in auto mode by default.

## Test plan
- [ ] `nx check`
- [ ] `nx up -hm` and confirm Claude Code starts in auto mode