### PR TITLE
Fix gh auth activation failing on read-only config.yml

### DIFF
--- a/nix/modules/home/gh.nix
+++ b/nix/modules/home/gh.nix
@@ -26,6 +26,11 @@ in
   # Dock-launched GUI apps (Claude Code UI, VS Code) and non-interactive subshells
   # spawn `gh` without that alias and without the shell env, so authentication fails.
   # Persisting the token in gh's own config file makes `gh` work everywhere.
+  #
+  # `gh auth login` writes to both hosts.yml AND config.yml, but config.yml is a
+  # read-only Nix-store symlink (managed by programs.gh.settings). We isolate gh
+  # in a temporary GH_CONFIG_DIR so its writes to config.yml are harmless, then
+  # copy only the resulting hosts.yml to the real location.
   home.activation.ghAuth = lib.mkIf (!isPlaceholderToken) (
     lib.hm.dag.entryAfter [ "writeBoundary" ] ''
       hosts_file="$HOME/.config/gh/hosts.yml"
@@ -36,13 +41,17 @@ in
       if [ "$current" != "${githubDevToken}" ]; then
         echo -e "\033[0;34mℹ\033[0m Persisting gh CLI authentication to $hosts_file"
         mkdir -p "$HOME/.config/gh"
+        tmp_dir=$(mktemp -d)
+        trap 'rm -rf "$tmp_dir"' EXIT
         # Clear any ambient GitHub tokens so gh persists the token to disk rather than
         # deferring to an env var (which wouldn't survive in Dock-launched app subprocesses).
         env -u GITHUB_TOKEN -u GH_TOKEN -u GH_ENTERPRISE_TOKEN -u GITHUB_ENTERPRISE_TOKEN \
+          GH_CONFIG_DIR="$tmp_dir" \
           ${pkgs.gh}/bin/gh auth login \
             --hostname github.com \
             --git-protocol ssh \
             --with-token <<< "${githubDevToken}"
+        install -m 600 "$tmp_dir/hosts.yml" "$hosts_file"
       fi
     ''
   );


### PR DESCRIPTION
## Summary
- `gh auth login --with-token` writes to both `hosts.yml` and `config.yml`, but `config.yml` is a read-only Nix-store symlink managed by `programs.gh.settings`, so the `ghAuth` activation failed with `open /Users/.../config.yml: permission denied` on `nx up`
- Isolate `gh auth login` in a temporary `GH_CONFIG_DIR` so its writes to `config.yml` land in a throwaway dir, then `install -m 600` only the resulting `hosts.yml` to the real location
- `config.yml` remains fully declarative via `programs.gh.settings` — no mutable-files extension needed

## Test plan
- [x] `nix eval nix/#darwinConfigurations.macbook_setup.system --apply 'x: "ok"'` passes
- [x] `nix eval nix/#darwinConfigurations.work_macbook.system --apply 'x: "ok"'` passes
- [x] `nx up` applies cleanly on the personal machine
- [x] `~/.config/gh/hosts.yml` is 0600 with persisted auth; `config.yml` stays a Nix-store symlink
- [x] `gh auth status` confirms login works