### PR TITLE
Manage .npmrc as a mutable config file

### DIFF
--- a/bin/nx
+++ b/bin/nx
@@ -457,13 +457,14 @@ json_files_equal() {
 }
 # Must match mutablePaths in nix/modules/home/mutable-files.nix
 # Ordered list of shorthand names (used for iteration order)
-MANAGED_NAMES=(claude op vscode vsmcp)
+MANAGED_NAMES=(claude op npmrc vscode vsmcp)
 BASELINE_DIR="$HOME/.local/share/nix-managed-baselines"
 
 # Shorthand -> full path mapping
 declare -A MANAGED_FILES=(
     [claude]=".claude/settings.json"
     [op]=".config/op/plugins.sh"
+    [npmrc]=".npmrc"
     [vscode]="Library/Application Support/Code/User/settings.json"
     [vsmcp]="Library/Application Support/Code/User/mcp.json"
 )
@@ -472,6 +473,7 @@ declare -A MANAGED_FILES=(
 declare -A MANAGED_NIX_SOURCES=(
     [claude]="nix/modules/home/claude.nix"
     [op]="nix/modules/home/onepassword.nix"
+    [npmrc]="nix/modules/home/npmrc.nix"
     [vscode]="nix/modules/home/vscode.nix"
     [vsmcp]="nix/modules/home/vscode.nix"
 )

--- a/completions/_nx
+++ b/completions/_nx
@@ -47,6 +47,7 @@ _nx() {
     managed_names=(
         'claude:.claude/settings.json'
         'op:.config/op/plugins.sh'
+        'npmrc:.npmrc'
         'vscode:Library/Application Support/Code/User/settings.json'
         'vsmcp:Library/Application Support/Code/User/mcp.json'
         'all:All managed files'

--- a/nix/modules/home/mutable-files.nix
+++ b/nix/modules/home/mutable-files.nix
@@ -4,6 +4,7 @@ let
   mutablePaths = [
     ".claude/settings.json"
     ".config/op/plugins.sh"
+    ".npmrc"
     "Library/Application Support/Code/User/settings.json"
     "Library/Application Support/Code/User/mcp.json"
   ];


### PR DESCRIPTION
## Summary
- Add `.npmrc` to `mutablePaths` in `mutable-files.nix` so Home Manager deploys a writable copy instead of a read-only symlink
- Wire `npmrc` shorthand into `bin/nx` (`MANAGED_NAMES`, `MANAGED_FILES`, `MANAGED_NIX_SOURCES` → `nix/modules/home/npmrc.nix`)
- Add `npmrc` entry to zsh completions in `completions/_nx`

## Test plan
- [x] `nx check` passes
- [x] `nx diff` shows the expected activation-script change
- [x] `nx up -hm` converts the existing `~/.npmrc` symlink to a writable copy on first run
- [x] `nx m` lists `npmrc` with correct status
- [x] `nx m d npmrc` and `nx m a npmrc` resolve to `nix/modules/home/npmrc.nix`
- [x] Zsh completion offers `npmrc` after `nx m d <TAB>`