### PR TITLE
Gate .npmrc mutable deploy on isWorkMachine

### DIFF
--- a/bin/nx
+++ b/bin/nx
@@ -172,6 +172,7 @@ apply_config() {
 
     if [[ "$force" == true ]]; then
         log_info "Reverting managed files to Nix baseline before applying..."
+        register_work_managed_files
         managed_revert all
     fi
 
@@ -457,14 +458,13 @@ json_files_equal() {
 }
 # Must match mutablePaths in nix/modules/home/mutable-files.nix
 # Ordered list of shorthand names (used for iteration order)
-MANAGED_NAMES=(claude op npmrc vscode vsmcp)
+MANAGED_NAMES=(claude op vscode vsmcp)
 BASELINE_DIR="$HOME/.local/share/nix-managed-baselines"
 
 # Shorthand -> full path mapping
 declare -A MANAGED_FILES=(
     [claude]=".claude/settings.json"
     [op]=".config/op/plugins.sh"
-    [npmrc]=".npmrc"
     [vscode]="Library/Application Support/Code/User/settings.json"
     [vsmcp]="Library/Application Support/Code/User/mcp.json"
 )
@@ -473,10 +473,19 @@ declare -A MANAGED_FILES=(
 declare -A MANAGED_NIX_SOURCES=(
     [claude]="nix/modules/home/claude.nix"
     [op]="nix/modules/home/onepassword.nix"
-    [npmrc]="nix/modules/home/npmrc.nix"
     [vscode]="nix/modules/home/vscode.nix"
     [vsmcp]="nix/modules/home/vscode.nix"
 )
+
+# Work-machine-only managed files. Lazily added so non-managed commands
+# don't pay the get_config_name cost (which may hit 1Password).
+register_work_managed_files() {
+    if [[ "$(get_config_name)" == "work_macbook" ]]; then
+        MANAGED_NAMES+=(npmrc)
+        MANAGED_FILES[npmrc]=".npmrc"
+        MANAGED_NIX_SOURCES[npmrc]="nix/modules/home/npmrc.nix"
+    fi
+}
 
 # Resolve a filter to a list of shorthand names
 # Sets RESOLVED_NAMES array
@@ -712,6 +721,7 @@ case "${1:-help}" in
         ;;
     managed|m)
         shift || true
+        register_work_managed_files
         case "${1:-}" in
             diff|d)
                 shift || true

--- a/completions/_nx
+++ b/completions/_nx
@@ -47,11 +47,13 @@ _nx() {
     managed_names=(
         'claude:.claude/settings.json'
         'op:.config/op/plugins.sh'
-        'npmrc:.npmrc'
         'vscode:Library/Application Support/Code/User/settings.json'
         'vsmcp:Library/Application Support/Code/User/mcp.json'
         'all:All managed files'
     )
+    # npmrc is work-machine-only; suggest it only if a baseline exists
+    [[ -f "$HOME/.local/share/nix-managed-baselines/.npmrc" ]] && \
+        managed_names+=('npmrc:.npmrc')
 
     if (( CURRENT == 2 )); then
         _describe 'command' commands

--- a/nix/modules/home/mutable-files.nix
+++ b/nix/modules/home/mutable-files.nix
@@ -1,12 +1,13 @@
-{ config, lib, homeDirectory, ... }:
+{ config, lib, homeDirectory, isWorkMachine ? false, ... }:
 
 let
   mutablePaths = [
     ".claude/settings.json"
     ".config/op/plugins.sh"
-    ".npmrc"
     "Library/Application Support/Code/User/settings.json"
     "Library/Application Support/Code/User/mcp.json"
+  ] ++ lib.optionals isWorkMachine [
+    ".npmrc"
   ];
 
   mutableFiles = map (path: {


### PR DESCRIPTION
## Summary
- `npmrc.nix` is only loaded in `workHomeModules`, so on the personal machine `home.file.".npmrc"` has no definition
- `mutable-files.nix` accessed `config.home.file.".npmrc".source` unconditionally, breaking `nx up` on the personal machine with "option has no value defined"
- Gate `.npmrc` in `mutablePaths` behind `isWorkMachine` using `lib.optionals`, matching where `npmrc.nix` is actually loaded

## Test plan
- [x] `nix eval nix/#darwinConfigurations.macbook_setup.system --apply 'x: "ok"'` succeeds
- [x] `nix eval nix/#darwinConfigurations.work_macbook.system --apply 'x: "ok"'` succeeds
- [x] `nx up` applies cleanly on personal machine
- [x] Work machine still deploys `.npmrc` as a mutable file on next `nx up`