### PR TITLE
Update default Ruby version to 4.0.3

### DIFF
--- a/nix/modules/home/ruby.nix
+++ b/nix/modules/home/ruby.nix
@@ -1,10 +1,10 @@
 { lib, pkgs,... }:
 
 let
-  latestRubyVersion = "4.0.2";
+  latestRubyVersion = "4.0.3";
   rubyVersions = [
     "3.4.8"
-    "4.0.1"
+    "4.0.2"
     latestRubyVersion
   ];
 in


### PR DESCRIPTION
## Summary
- Bump `latestRubyVersion` from 4.0.2 to 4.0.3 in `nix/modules/home/ruby.nix`
- Retain 4.0.2 in the managed versions list (drops 4.0.1), matching the pattern from #171

## Test plan
- [x] `nx check` passes
- [x] `nx diff` shows expected version bump
- [x] `nx up -hm` activation installs Ruby 4.0.3 via mise
- [x] `ruby -v` reports 4.0.3 in a fresh shell

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Ruby versions: the default Ruby version is now set to 4.0.3, replacing the previous default. The list of available Ruby versions has been updated to include 4.0.2 and other supported versions, ensuring all users have access to the latest stable Ruby releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->