### PR TITLE
Fix JSON false-conflicts in mutable-files; bump home-manager and nix-index-database

### DIFF
--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -82,11 +82,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775365369,
-        "narHash": "sha256-DgH5mveLoau20CuTnaU5RXZWgFQWn56onQ4Du2CqYoI=",
+        "lastModified": 1777181277,
+        "narHash": "sha256-yVJbd07ortDRAttDFmDV5p220aOLTHgVAx//0nW/xW8=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "cef5cf82671e749ac87d69aadecbb75967e6f6c3",
+        "rev": "b8eb7acee0f7604fe1bf6a5b3dcf5254369180fa",
         "type": "github"
       },
       "original": {

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -24,11 +24,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775781825,
-        "narHash": "sha256-L5yKTpR+alrZU2XYYvIxCeCP4LBHU5jhwSj7H1VAavg=",
+        "lastModified": 1777236726,
+        "narHash": "sha256-ZTYDofOM3/PJhRF1EuBh6uibm+DmkhU7Wor6mMN7YTc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e35c39fca04fee829cecdf839a50eb9b54d8a701",
+        "rev": "e82d4a4ecd18363aa2054cbaa3e32e4134c3dbf4",
         "type": "github"
       },
       "original": {

--- a/nix/modules/home/codex.nix
+++ b/nix/modules/home/codex.nix
@@ -16,7 +16,7 @@
       mcp_servers = mcpServers;
     };
 
-    custom-instructions = ''
+    context = ''
       # User Configuration
       - Prefer object-oriented programming patterns where applicable
       - Use descriptive variable names and clear code structure

--- a/nix/modules/home/mutable-files.nix
+++ b/nix/modules/home/mutable-files.nix
@@ -1,4 +1,4 @@
-{ config, lib, homeDirectory, isWorkMachine ? false, ... }:
+{ config, lib, pkgs, homeDirectory, isWorkMachine ? false, ... }:
 
 let
   mutablePaths = [
@@ -27,6 +27,24 @@ in
 
   # Deploy writable copies with conflict detection
   home.activation.deployMutableFiles = lib.hm.dag.entryAfter [ "linkGeneration" ] ''
+    # JSON-aware equality: matches `nx m d` so byte-different but semantically
+    # identical JSON (key reorder, whitespace, trailing newline) isn't flagged
+    # as a conflict.
+    files_equal() {
+      local a="$1" b="$2"
+      case "$a" in
+        *.json)
+          local na nb
+          if na=$(${pkgs.jq}/bin/jq -S . "$a" 2>/dev/null) \
+            && nb=$(${pkgs.jq}/bin/jq -S . "$b" 2>/dev/null); then
+            [ "$na" = "$nb" ]
+            return
+          fi
+          ;;
+      esac
+      cmp -s "$a" "$b"
+    }
+
     deploy_mutable_file() {
       local rel_path="$1"
       local store_path="$2"
@@ -55,13 +73,13 @@ in
       fi
 
       # Case 3: Target content matches Nix content — no conflict, update baseline
-      if cmp -s "$target" "$store_path"; then
+      if files_equal "$target" "$store_path"; then
         install -m 644 "$store_path" "$baseline"
         return
       fi
 
       # Case 4: Target matches baseline — app didn't change, safe to overwrite
-      if [ -f "$baseline" ] && cmp -s "$target" "$baseline"; then
+      if [ -f "$baseline" ] && files_equal "$target" "$baseline"; then
         install -m 644 "$store_path" "$target"
         install -m 644 "$store_path" "$baseline"
         echo -e "\033[0;32m✓\033[0m Updated writable copy: $rel_path"


### PR DESCRIPTION
## Summary
- Activation script now uses `jq -S` JSON-normalized compare for `.json` mutable files, mirroring `nx m d`. Apps like Claude Code rewrite `settings.json` with different key order or whitespace; previously this tripped a false `mutable-files WARNING: conflict detected` even though `nx m d` reported no changes.
- Bumps `home-manager` to pick up the `programs.codex.custom-instructions` → `programs.codex.context` rename and updates the codex module to the new option name (silences the `nx up` deprecation warning).
- Bumps `nix-index-database` to its latest snapshot.

## Test plan
- [x] `nx check` passes
- [x] `nx up` no longer emits `mutable-files WARNING: conflict detected in .claude/settings.json` when the file is JSON-equal to the baseline
- [x] `nx m d` continues to report `claude no changes`
- [x] Codex `custom-instructions → context` deprecation warning is gone