### PR TITLE
Make ren completions case-insensitive

### DIFF
--- a/completions/_ren
+++ b/completions/_ren
@@ -4,13 +4,15 @@
 
 _ren() {
     # Case-insensitive matching baked into every compadd via the `-M` match
-    # spec. Doing this at the compadd layer avoids having to reason about
-    # zstyle contexts or fzf-tab interception — these specs always apply.
+    # spec — applies regardless of zstyle context or fzf-tab interception.
     #   m:{a-zA-Z}={A-Za-z}   — case-insensitive, both directions
-    #   r:|[._-]=* r:|=*      — partial-word at `._-` separators
-    #   l:|=* r:|=*           — substring anywhere
+    #   r:|[._-]=*            — let typed string match starting at any
+    #                            `._-` separator (so `sun` → `Chasing-Sunsets`)
+    # Deliberately NOT including `l:|=*` / `r:|=*` (substring-anywhere):
+    # those let a single character match mid-word in multiple candidates,
+    # which confuses zsh's common-prefix calculation (e.g. `d` → `ad`).
     local -a ren_match_specs=(
-        -M 'm:{a-zA-Z}={A-Za-z} r:|[._-]=* r:|=* l:|=* r:|=*'
+        -M 'm:{a-zA-Z}={A-Za-z} r:|[._-]=*'
     )
 
     local -a commands

--- a/completions/_ren
+++ b/completions/_ren
@@ -3,17 +3,15 @@
 # Zsh completion for ren (Ren'Py game manager)
 
 _ren() {
-    # Case-insensitive matching for ren completions: `ren launch g` should
-    # offer `GameName`. Falls back through progressively looser matchers:
-    #   1. exact prefix
-    #   2. case-insensitive (typed `g` ↔ candidate `G`, both directions)
-    #   3. partial-word at separators (`-` `_` `.`)
-    #   4. substring anywhere
-    zstyle ':completion:*:*:ren:*' matcher-list \
-        '' \
-        'm:{a-zA-Z}={A-Za-z}' \
-        'r:|[._-]=* r:|=*' \
-        'l:|=* r:|=*'
+    # Case-insensitive matching baked into every compadd via the `-M` match
+    # spec. Doing this at the compadd layer avoids having to reason about
+    # zstyle contexts or fzf-tab interception — these specs always apply.
+    #   m:{a-zA-Z}={A-Za-z}   — case-insensitive, both directions
+    #   r:|[._-]=* r:|=*      — partial-word at `._-` separators
+    #   l:|=* r:|=*           — substring anywhere
+    local -a ren_match_specs=(
+        -M 'm:{a-zA-Z}={A-Za-z} r:|[._-]=* r:|=* l:|=* r:|=*'
+    )
 
     local -a commands
     commands=(
@@ -42,7 +40,7 @@ _ren() {
             names+=("$base")
         done
         names=(${(u)${(o)names}})
-        compadd -a names
+        compadd "${ren_match_specs[@]}" -a names
     }
 
     _ren_cleanup_targets() {
@@ -56,7 +54,7 @@ _ren() {
 
     _ren_help_topics() {
         local -a topics=(install launch list cleanup mod)
-        compadd -a topics
+        compadd "${ren_match_specs[@]}" -a topics
     }
 
     _ren_archives() {

--- a/completions/_ren
+++ b/completions/_ren
@@ -3,6 +3,18 @@
 # Zsh completion for ren (Ren'Py game manager)
 
 _ren() {
+    # Case-insensitive matching for ren completions: `ren launch g` should
+    # offer `GameName`. Falls back through progressively looser matchers:
+    #   1. exact prefix
+    #   2. case-insensitive (typed `g` ↔ candidate `G`, both directions)
+    #   3. partial-word at separators (`-` `_` `.`)
+    #   4. substring anywhere
+    zstyle ':completion:*:*:ren:*' matcher-list \
+        '' \
+        'm:{a-zA-Z}={A-Za-z}' \
+        'r:|[._-]=* r:|=*' \
+        'l:|=* r:|=*'
+
     local -a commands
     commands=(
         'install:Install a game from archive'


### PR DESCRIPTION
## Summary
- Adds a scoped `matcher-list` zstyle inside `_ren()` so `ren launch g<TAB>` now offers `GameName` without requiring the capital letter.
- Falls back through four progressively looser passes: exact prefix → case-insensitive (both directions) → partial-word at `._-` separators → substring anywhere.
- Scoped to `:completion:*:*:ren:*` so it doesn't leak into other commands' completions.

## Test plan
- [ ] Reload completion: `unfunction _ren && autoload -Uz _ren` (or open new shell)
- [ ] `ren launch g<TAB>` suggests `GameName` / other capitalized games
- [ ] `ren launch sun<TAB>` matches `Chasing-Sunsets` (substring fallback)
- [ ] `ren cleanup game c<TAB>` and `ren mod c<TAB>` also benefit
- [ ] Non-ren completions (e.g. `git`, `nx`) unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-completion for the ren command is now case-insensitive.
  * Matching better supports partial and substring matches that start at common separators (., _, -) for faster selection.
  * Smarter completions applied uniformly to both game-name and help-topic suggestions for a more intuitive experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->