### PR TITLE
chore: ignore claude worktrees globally and add linear cask

### DIFF
--- a/nix/modules/home/git.nix
+++ b/nix/modules/home/git.nix
@@ -64,6 +64,7 @@ in
 
       # AI tool settings
       "**/.claude/settings.local.json"
+      "**/.claude/worktrees/"
     ];
 
     settings = {

--- a/nix/modules/system/homebrew.nix
+++ b/nix/modules/system/homebrew.nix
@@ -51,6 +51,7 @@ let
   workOnlyCasks = [
     "gather"
     "grammarly-desktop"
+    "linear-linear"
     "meetingbar"
     "tuple"
     "wispr-flow"


### PR DESCRIPTION
## Summary
- Add `**/.claude/worktrees/` to the global gitignore so Claude Code's isolated worktrees (e.g. `Agent({ isolation: "worktree" })`) stop showing up as untracked entries in parent repos.
- Add `linear-linear` to the work-only Homebrew casks list.

## Test plan
- [x] `nx up` applied cleanly
- [x] Verify `git status` in a repo containing `.claude/worktrees/` no longer flags the directory


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Git configuration to exclude `.claude/worktrees/` directories from version control tracking.
  * Added Linear-linear application to work machine software installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->