### PR TITLE
chore: enable datadog-analytics plugin on work machine

### DIFF
--- a/nix/modules/home/claude.nix
+++ b/nix/modules/home/claude.nix
@@ -562,7 +562,7 @@ in
         "lua-lsp@claude-plugins-official" = true;
         "ruby-lsp@claude-plugins-official" = true;
         "notion-markdown@babylist" = isWorkMachine;
-        "branch-context@babylist" = isWorkMachine;
+        "datadog-analytics@babylist" = isWorkMachine;
         "skill-creator@claude-plugins-official" = false;
 
         # Local plugins

--- a/nix/modules/home/claude.nix
+++ b/nix/modules/home/claude.nix
@@ -562,6 +562,7 @@ in
         "lua-lsp@claude-plugins-official" = true;
         "ruby-lsp@claude-plugins-official" = true;
         "notion-markdown@babylist" = isWorkMachine;
+        "branch-context@babylist" = isWorkMachine;
         "skill-creator@claude-plugins-official" = false;
 
         # Local plugins


### PR DESCRIPTION
## Summary
- Enable `datadog-analytics@babylist` plugin in Claude Code, gated by `isWorkMachine` so it only activates on the work machine.

## Test plan
- [x] `nx up` applies cleanly
- [x] Verify plugin loads on work machine
- [ ] Confirm plugin is absent on personal machine


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Datadog Analytics plugin to Claude Code, enabled by default on work machines.
  * No other Claude Code permissions, configurations, or plugin entries were modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->