### PR TITLE
chore: rename linear-linear cask to linear

### DIFF
--- a/nix/modules/system/homebrew.nix
+++ b/nix/modules/system/homebrew.nix
@@ -51,7 +51,7 @@ let
   workOnlyCasks = [
     "gather"
     "grammarly-desktop"
-    "linear-linear"
+    "linear"
     "meetingbar"
     "tuple"
     "wispr-flow"


### PR DESCRIPTION
## Summary
- Update the work-only Homebrew cask name from `linear-linear` to `linear` to match the upstream rename in homebrew-cask.

## Test plan
- [x] `brew info --cask linear` resolves
- [x] `nix eval nix#darwinConfigurations.macbook_setup.system --apply 'x: "ok"'` succeeds
- [x] `nx up` on the work machine installs the renamed cask without error


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Linear application installation package configuration for work machine setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->