### PR TITLE
chore: remove code-review plugin from enabled plugins

### DIFF
--- a/nix/modules/home/claude.nix
+++ b/nix/modules/home/claude.nix
@@ -542,7 +542,6 @@ in
       enabledPlugins = {
         "claude-code-setup@claude-plugins-official" = true;
         "claude-md-management@claude-plugins-official" = true;
-        "code-review@claude-plugins-official" = true;
         "code-simplifier@claude-plugins-official" = true;
         "commit-commands@claude-plugins-official" = true;
         "frontend-design@claude-plugins-official" = true;


### PR DESCRIPTION
## Summary
- Disables `code-review@claude-plugins-official` in Claude Code's enabled plugins, since the existing `pr-review-toolkit` and `superpowers` code-reviewer agents already cover this functionality.

## Test plan
- [x] `nx check` passes
- [x] `nx diff` shows only the expected plugin removal
- [x] `nx up -hm` applies cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled the code review plugin from the module configuration, making it no longer available through the default setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->