### PR TITLE
chore: quiet homebrew bundle output during activation

### DIFF
--- a/nix/modules/system/homebrew.nix
+++ b/nix/modules/system/homebrew.nix
@@ -143,8 +143,10 @@ in
       extraEnv = {
         HOMEBREW_NO_ENV_HINTS = "1";
         HOMEBREW_NO_ANALYTICS = "1";
+        HOMEBREW_NO_ANALYTICS_MESSAGE_OUTPUT = "1";
         HOMEBREW_NO_UPDATE_REPORT_NEW = "1";
       };
+      extraFlags = [ "--quiet" ];
     };
   };
 


### PR DESCRIPTION
## Summary
- Add `HOMEBREW_NO_ANALYTICS_MESSAGE_OUTPUT=1` to `homebrew.onActivation.extraEnv` to suppress the "analytics moved to InfluxDB / please reconsider re-enabling" block. The normal "displayed once" gating is TTY-conditional in brew (`update-report.rb:336`), so `darwin-rebuild`'s non-TTY activation never persists the flag and the message reprints every run.
- Add `extraFlags = [ "--quiet" ]` so `brew bundle` skips the `Using <pkg>` lines for already-installed entries while leaving real install/upgrade output intact (`bundle/installer.rb:94`).

## Test plan
- [ ] `nx check`
- [ ] `nx up` and confirm the analytics paragraph and `Using ...` lines are gone, while any actual install/upgrade output still appears
- [ ] Donation message will still appear under activation until manually marked displayed (out of scope)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced system configuration to minimize verbose analytics notifications from the package manager. The updated settings reduce informational messages displayed during installation and management operations, providing users with a cleaner, more streamlined command-line experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->