### PR TITLE
chore: align activation script output with icon prefix style

### DIFF
--- a/nix/modules/system/autoclick.nix
+++ b/nix/modules/system/autoclick.nix
@@ -22,13 +22,13 @@ let
 in
 {
   system.activationScripts.postActivation.text = ''
-    echo "Checking for AutoClick installation..."
+    echo -e "\033[0;34mℹ\033[0m Checking for AutoClick installation..."
     if [ ! -d "/Applications/Autoclick.app" ]; then
-      echo -e "\033[0;34mAutoClick not found. Installing from Nix store...\033[0m"
+      echo -e "\033[0;34mℹ\033[0m AutoClick not found. Installing from Nix store..."
       cp -r "${autoclick}/Applications/Autoclick.app" /Applications/
-      echo -e "\033[0;32mAutoClick installed successfully.\033[0m"
+      echo -e "\033[0;32m✓\033[0m AutoClick installed successfully."
     else
-      echo -e "\033[0;32mAutoClick is already installed.\033[0m"
+      echo -e "\033[0;32m✓\033[0m AutoClick is already installed."
     fi
   '';
 }

--- a/nix/modules/system/pwa-apps.nix
+++ b/nix/modules/system/pwa-apps.nix
@@ -6,7 +6,7 @@ let
 in
 {
   system.activationScripts.postActivation.text = ''
-    echo -e "\033[0;34mChecking and linking PWA apps...\033[0m"
+    echo -e "\033[0;34mℹ\033[0m Checking and linking PWA apps..."
 
     # Loop through all .app directories in the source directory
     for app in ${pwaAppsSourceDir}/*.app; do
@@ -14,13 +14,13 @@ in
       targetPath="${appsDir}/$appName"
 
       if [ ! -e "$targetPath" ]; then
-        echo -e "\033[0;34mLinking $appName...\033[0m"
+        echo -e "\033[0;34mℹ\033[0m Linking $appName..."
         ${pkgs.coreutils}/bin/ln -sf "$app" "$targetPath"
       else
-        echo -e "\033[0;32m$appName is already linked.\033[0m"
+        echo -e "\033[0;32m✓\033[0m $appName is already linked."
       fi
     done
 
-    echo -e "\033[0;34mPWA apps linking completed.\033[0m"
+    echo -e "\033[0;32m✓\033[0m PWA apps linking completed."
   '';
 }


### PR DESCRIPTION
## Summary
- Update `pwa-apps.nix` and `autoclick.nix` activation scripts to use the blue `ℹ` / green `✓` icon prefix style with normal-colored text, matching the convention already used in `ruby.nix`, `mutable-files.nix`, and `system-defaults.nix`.
- Removes the inconsistent fully-colored lines that appeared between the homebrew bundle output and the home-manager activation output.

## Test plan
- [ ] `nx check` passes
- [ ] `nx up` runs and the PWA / AutoClick lines render with the new prefix style

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved system message formatting during AutoClick detection and PWA app linking operations. Status messages now display with color-coded feedback and visual indicators for clearer, more user-friendly output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->