### PR TITLE
chore: use #!/usr/bin/env bash shebang for portability

### DIFF
--- a/nix/modules/home/ai-globals.nix
+++ b/nix/modules/home/ai-globals.nix
@@ -51,7 +51,7 @@ let
     ];
 
     shellScripting = [
-      "Use #!/bin/bash shebang"
+      "Use #!/usr/bin/env bash shebang for portability (picks up Homebrew bash on macOS, finds bash via PATH on systems where it isn't at /bin/bash)"
       "Include 'set -euo pipefail' for safety"
       "Must pass shellcheck validation"
       "**1Password Plugin Pattern**: For CLI tools with 1Password plugin support in non-interactive subshells where the shell alias isn't visible, wrap commands with 'op plugin run --'. Not needed for 'gh': its token is persisted at ~/.config/gh/hosts.yml by gh.nix, so 'gh' works directly from any context."
@@ -213,7 +213,7 @@ in
 
       Always include:
       ```bash
-      #!/bin/bash
+      #!/usr/bin/env bash
       set -euo pipefail
       ```
     '';


### PR DESCRIPTION
## Summary
- Switch the global AI shell-scripting guidance in `ai-globals.nix` from `#!/bin/bash` to `#!/usr/bin/env bash`
- Pick up Homebrew bash on macOS and resolve bash via `PATH` on systems where it isn't at `/bin/bash`

## Test plan
- [ ] `nx check` passes
- [ ] `nx diff` shows only the expected text update in generated `~/.claude/CLAUDE.md`, `~/.config/AGENTS.md`, and `~/.gemini/GEMINI.md`
- [ ] `nx up -hm` applies cleanly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved shell script portability in global configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->