### PR TITLE
ssh: source agent socket and host config from 1Password

### DIFF
--- a/bin/nixup-with-secrets
+++ b/bin/nixup-with-secrets
@@ -164,6 +164,8 @@ load_secrets() {
         "NIX_GITHUB_DEV_TOKEN|github_json|dev_token|GitHub dev token (gh CLI auth)|false"
         "NIX_WORK_HOSTNAME|work_json|hostname|work hostname|false"
         "NIX_SIERRA_AUTH_TOKEN|work_json|sierra_auth_token|Sierra AI auth token|false"
+        "NIX_BASTION_DOMAIN|work_json|bastion_domain|bastion domain|false"
+        "NIX_SSH_BABYLIST_BASTION_KEY|work_json|bastion_ssh_key|bastion SSH public key|false"
     )
 
     local secrets_loaded=0

--- a/nix/modules/home/ssh.nix
+++ b/nix/modules/home/ssh.nix
@@ -64,6 +64,13 @@ let
   # quoting/subshell issues in ssh config
   onePasswordAgentSymlink = "${config.home.homeDirectory}/.ssh/1password-agent.sock";
 
+  # Domain + key sourced from 1Password (Nix/Work); staging derived from prod.
+  bastionDomain = getEnvOrFallback "NIX_BASTION_DOMAIN" "bastion.bootstrap.invalid" "bastion.placeholder.invalid";
+  bastionKey = getEnvOrFallback "NIX_SSH_BABYLIST_BASTION_KEY" "ssh-ed25519 BOOTSTRAP_BASTION_KEY" "ssh-ed25519 PLACEHOLDER_BASTION_KEY_CHANGE_ME";
+  bastionKeyFile = "babylist";
+  bastionStageDomain = builtins.replaceStrings [ "-prod." ] [ "-stage." ] bastionDomain;
+  bastionConfigured = bastionDomain != "bastion.placeholder.invalid" && bastionDomain != "bastion.bootstrap.invalid";
+
 in
 {
   programs.ssh =
@@ -124,6 +131,22 @@ in
         };
       };
 
+      # identityAgent + identitiesOnly inherited from "*"; pinned IdentityFile
+      # selects the agent-held key. user "deploy" matches baby-cli.
+      bastionBlocks = lib.optionalAttrs bastionConfigured ({
+        "${bastionDomain}" = {
+          hostname = bastionDomain;
+          user = "deploy";
+          identityFile = "~/.ssh/${bastionKeyFile}";
+        };
+      } // lib.optionalAttrs (bastionStageDomain != bastionDomain) {
+        "${bastionStageDomain}" = {
+          hostname = bastionStageDomain;
+          user = "deploy";
+          identityFile = "~/.ssh/${bastionKeyFile}";
+        };
+      });
+
     in {
       enable = true;
       enableDefaultConfig = false;
@@ -136,11 +159,13 @@ in
           hostname = "github.com";
           identityFile = "~/.ssh/${mainGithubKeyFile}";
         };
-      } // lib.optionalAttrs (!isWorkMachine) personalBlocks;
+      } // bastionBlocks // lib.optionalAttrs (!isWorkMachine) personalBlocks;
     };
 
   home.file = {
     "${sshDir}/${mainGithubKeyFile}.pub".text = "${mainGithubKey} ${personalEmail}";
+  } // lib.optionalAttrs bastionConfigured {
+    "${sshDir}/${bastionKeyFile}.pub".text = bastionKey;
   } // lib.optionalAttrs (!isWorkMachine) {
     "${sshDir}/${mainServerKeyFile}.pub".text = "${mainServerKey} ${macbook_hostname}";
     "${sshDir}/${nvmServerKeyFile}.pub".text = "${nvmServerKey} ${macbook_hostname}";

--- a/nix/modules/home/zsh.nix
+++ b/nix/modules/home/zsh.nix
@@ -145,6 +145,10 @@ in
     sessionVariables = {
       EDITOR = "code --wait";
 
+      # Point at the 1Password agent so tools reading SSH_AUTH_SOCK directly
+      # (e.g. baby-cli / Net::SSH, which ignore ssh_config IdentityAgent) work.
+      SSH_AUTH_SOCK = "${config.home.homeDirectory}/.ssh/1password-agent.sock";
+
       # Claude Code configuration
       DISABLE_TELEMETRY = "false";
       DISABLE_ERROR_REPORTING = "false";


### PR DESCRIPTION
Point SSH_AUTH_SOCK at the 1Password agent socket for tools that read it directly, and add SSH host blocks whose domain and key are pulled from 1Password.