### PR TITLE
ssh: offer agent keys for host blocks (identitiesOnly=false)

### DIFF
--- a/nix/modules/home/ssh.nix
+++ b/nix/modules/home/ssh.nix
@@ -131,22 +131,22 @@ in
         };
       };
 
-      # identitiesOnly=false so baby/Net::SSH offers agent keys: it can't match
-      # a .pub-only IdentityFile under keys_only (private key lives in 1Password).
-      # IdentityFile still makes OpenSSH try babylist first. user = baby console user.
+      # extraOptions forces "IdentitiesOnly no": home-manager omits the line when
+      # false, so "*" imposes "yes" and Net::SSH (keys_only) offers 0 keys. These
+      # blocks precede "*", so this wins and the agent-held key gets offered.
       bastionBlocks = lib.optionalAttrs bastionConfigured ({
         "${bastionDomain}" = {
           hostname = bastionDomain;
           user = "deploy";
           identityFile = "~/.ssh/${bastionKeyFile}";
-          identitiesOnly = false;
+          extraOptions = { IdentitiesOnly = "no"; };
         };
       } // lib.optionalAttrs (bastionStageDomain != bastionDomain) {
         "${bastionStageDomain}" = {
           hostname = bastionStageDomain;
           user = "deploy";
           identityFile = "~/.ssh/${bastionKeyFile}";
-          identitiesOnly = false;
+          extraOptions = { IdentitiesOnly = "no"; };
         };
       });
 

--- a/nix/modules/home/ssh.nix
+++ b/nix/modules/home/ssh.nix
@@ -131,19 +131,22 @@ in
         };
       };
 
-      # identityAgent + identitiesOnly inherited from "*"; pinned IdentityFile
-      # selects the agent-held key. user "deploy" matches baby-cli.
+      # identitiesOnly=false so baby/Net::SSH offers agent keys: it can't match
+      # a .pub-only IdentityFile under keys_only (private key lives in 1Password).
+      # IdentityFile still makes OpenSSH try babylist first. user = baby console user.
       bastionBlocks = lib.optionalAttrs bastionConfigured ({
         "${bastionDomain}" = {
           hostname = bastionDomain;
           user = "deploy";
           identityFile = "~/.ssh/${bastionKeyFile}";
+          identitiesOnly = false;
         };
       } // lib.optionalAttrs (bastionStageDomain != bastionDomain) {
         "${bastionStageDomain}" = {
           hostname = bastionStageDomain;
           user = "deploy";
           identityFile = "~/.ssh/${bastionKeyFile}";
+          identitiesOnly = false;
         };
       });
 


### PR DESCRIPTION
Follow-up to the previous SSH host config. Sets `identitiesOnly = false` on those host blocks so agent-backed keys are actually offered — a `.pub`-only IdentityFile can't be matched under `keys_only`, so the agent key would otherwise never be presented.