### PR TITLE
fix(statusline): scale context bar to auto-compact trigger

### DIFF
--- a/nix/modules/home/claude.nix
+++ b/nix/modules/home/claude.nix
@@ -374,7 +374,9 @@ in
             if (model) parts.push("\x1b[2m" + model + "\x1b[0m");
             if (remaining != null) {
               const rawUsed = Math.max(0, Math.min(100, 100 - Math.round(remaining)));
-              const used = Math.min(100, Math.round((rawUsed / 80) * 100));
+              // Scale so the bar hits 100% near the auto-compact trigger (~92% of the
+              // real context window), not at full. rawUsed is the true window-used %.
+              const used = Math.min(100, Math.round((rawUsed / 92) * 100));
               const filled = Math.floor(used / 10);
               const bar = "▰".repeat(filled) + "▱".repeat(10 - filled);
               let color;


### PR DESCRIPTION
## Summary

The status line's context progress bar was reading "100%" well before the context window was actually full — the chat would keep going a fair bit past 100% without compacting.

**Root cause:** `statusline.js` divided the real window-used percentage by `80` and capped at 100%, so the bar saturated at 100% once usage crossed 80% of the 200k window. That hid the top ~20% (~40k tokens) of real headroom and read "full" long before auto-compact fires.

The data from Claude Code (`context_window.remaining_percentage`) was always correct — only the display math was off.

**Fix:** change the divisor `80` → `92` so the bar hits 100% right as auto-compact (~92% of the window) actually triggers, and the red 🚨 warning band lights up in the ~90%+ danger zone.

## Behavior

| Real window usage | Old bar | New bar |
|---|---|---|
| 80% (~160k) | 100% | 87% (orange) |
| 90% (~180k) | 100% | 98% 🚨 red |
| 92% (~184k, auto-compact) | 100% | **100% 🚨** |

## Testing

- Verified the new scaling/color thresholds with a mock run of the formula across usage levels
- `nix eval nix/#darwinConfigurations.macbook_setup.system --apply 'x: "ok"'` → `ok`