### PR TITLE
fix(ren): keep install name and build tag consistent

### DIFF
--- a/bin/ren
+++ b/bin/ren
@@ -32,10 +32,16 @@ typeset -gr TEMP_CLEANUP_DAYS=7
 # Version and platform regex patterns
 # Numeric versions: v1.0, 0.36.dv-mac, 1.2.3a-pc
 typeset -gr VERSION_PATTERN='[vr]?[0-9]+\.[0-9]+(\.[0-9]+)?'
+# Build/release tag that can immediately trail a numeric version (no separator):
+# a single letter, a multi-letter tag (hotfix, release-candidate, beta...), or a
+# tag with a trailing number. Kept as its own pattern and captured INTO the
+# version so it isn't silently dropped — otherwise two builds that differ only
+# by their tag normalize to the same version and collide on one install path.
+typeset -gr VERSION_TAG_PATTERN='[a-z]+[0-9]*'
 # Episodic versions: S1-C1-E01-A (Season-Chapter-Episode-Version)
 typeset -gr EPISODIC_PATTERN='S[0-9]+-C[0-9]+-E[0-9]+-[A-Z]+'
 typeset -gr PLATFORM_SUFFIX_PATTERN='(\.(dv-mac|dv-win|dv-pc)|(-pc|-mac|-win|-linux))?'
-typeset -gr VERSION_FULL_PATTERN="${VERSION_PATTERN}[a-z]?${PLATFORM_SUFFIX_PATTERN}"
+typeset -gr VERSION_FULL_PATTERN="${VERSION_PATTERN}(${VERSION_TAG_PATTERN})?${PLATFORM_SUFFIX_PATTERN}"
 typeset -gr EPISODIC_FULL_PATTERN="${EPISODIC_PATTERN}${PLATFORM_SUFFIX_PATTERN}"
 
 # Supported archive extensions for mod installation
@@ -251,7 +257,9 @@ extract_version() {
     fi
 
     # Try numeric version pattern (v1.0, 1.0.1a, etc.)
-    local version_re="-[vr]?([0-9]+\.[0-9]+(\.[0-9]+)?)[a-z]?${PLATFORM_SUFFIX_PATTERN}"
+    # The trailing tag is inside the capture group so build tags (e.g. a hotfix
+    # suffix) are preserved in the returned version rather than truncated.
+    local version_re="-[vr]?([0-9]+\.[0-9]+(\.[0-9]+)?(${VERSION_TAG_PATTERN})?)${PLATFORM_SUFFIX_PATTERN}"
     if [[ "$basename" =~ $version_re ]]; then
         echo "${match[1]}"
         return 0
@@ -853,7 +861,11 @@ cmd_install() {
         echo "  Version: ${CYAN}$version${NC}"
     fi
     echo ""
-    echo "To play: ${CYAN}ren launch $game_name${NC}"
+    # Suggest the name that matches the installed directory. $game_name is the
+    # raw, un-normalized name parsed from the archive (a third spelling that
+    # only resolves by luck of find_game_dir's lenient fallback); $base_name is
+    # the normalized, dash-joined form that prefixes the actual install dir.
+    echo "To play: ${CYAN}ren launch $base_name${NC}"
 }
 
 # ============================================================================


### PR DESCRIPTION
## Problem

`ren install` surfaced the same game under inconsistent names, and dropped build tags from versions.

1. **Mismatched launch hint.** The "To play: `ren launch <name>`" line echoed the raw name parsed straight from the archive (preserving the original camelCase, no separators) — a *third* spelling, distinct from both the human-readable display name (spaced) and the actual install directory (dash-joined + version). It happened to still work only because `find_game_dir` has a lenient fallback that re-normalizes camelCase to dashes. The suggested command never matched the directory string it created.

2. **Truncated build tags.** `extract_version` allowed only a single optional letter after the numeric version, so multi-character build/release tags (hotfix, release-candidate, beta, etc.) were silently dropped. Consequence: two distinct builds that differ only by their tag normalized to the *same* version number and resolved to the *same* install path — a silent collision/overwrite risk.

## Fix

- Echo the normalized, dash-joined base name in the install summary so the suggested launch command matches the on-disk directory prefix.
- Add a dedicated build-tag pattern and capture it **into** the version, so the tag is preserved consistently across the displayed version, the install directory name, and `ren list`.

## Verification

Exercised the real parsing/normalization functions against a range of generic filename shapes (camelCase names, multi-word names, two- and three-part versions, single-letter tags, multi-char tags, tag-with-number, episodic, dotted-platform, and no-version). For Mac `.app` installs the version (with tag), display name, install directory, and launch hint all agree.

## Out of scope

`normalize_basename` uses zsh's `:r` to strip archive extensions; on Windows-build directories (which have no extension) it can clip a trailing `.N` version segment in the `ren list` display. That's a separate, pre-existing quirk and is not touched here.