### PR TITLE
Deny select GitHub MCP tools and add rm-guard hook

### DIFF
--- a/nix/modules/home/ai-globals.nix
+++ b/nix/modules/home/ai-globals.nix
@@ -190,7 +190,13 @@ in
 
       ### GitHub: MCP plugin over `gh` CLI
 
-      Use the GitHub MCP plugin (`mcp__plugin_github_github__*`) for all GitHub operations: reading issues/PRs/commits, creating branches, searching code, etc. Fall back to `gh` CLI only when the MCP plugin lacks the needed capability (e.g., `gh run` for workflow runs, `gh api` for arbitrary API calls, `gh pr checkout` for local checkout).
+      Use the GitHub MCP plugin (`mcp__plugin_github_github__*`) for most GitHub operations: reading PRs/commits, creating branches, searching code, etc. Fall back to `gh` CLI when the MCP plugin lacks the needed capability (e.g., `gh run` for workflow runs, `gh pr checkout` for local checkout).
+
+      A few MCP tools are deliberately denied — use the `gh` CLI instead:
+
+      - Reading issues (`issue_read`) → `gh issue view` / `gh issue list`
+      - Reading file contents (`get_file_contents`) → `gh api`
+      - Writing sub-issues (`sub_issue_write`) → `gh api`
 
       ### Browser: Playwright MCP vs Claude In Chrome
 

--- a/nix/modules/home/claude.nix
+++ b/nix/modules/home/claude.nix
@@ -189,7 +189,6 @@ let
   githubMcpReadTools = map ghMcp [
     "get_me"
     "get_commit"
-    "get_file_contents"
     "get_label"
     "get_latest_release"
     "get_release_by_tag"
@@ -197,7 +196,6 @@ let
     "get_team_members"
     "get_teams"
     "get_copilot_job_status"
-    "issue_read"
     "list_branches"
     "list_commits"
     "list_issues"
@@ -223,6 +221,11 @@ let
     "request_copilot_review"
     "pull_request_review_write"
     "add_comment_to_pending_review"
+  ];
+  # --- GitHub MCP tools to deny — use the gh CLI instead (see ~/.claude/CLAUDE.md) ---
+  githubMcpDenyTools = map ghMcp [
+    "issue_read"
+    "get_file_contents"
     "sub_issue_write"
   ];
   githubMcpAskTools = map ghMcp [
@@ -407,6 +410,19 @@ in
           fi
         '';
       };
+
+      # PreToolUse(Bash) guard: auto-approve `rm` only for temp/project-tmp/
+      # git-tracked targets; everything else falls through to the `ask rm:*` rule.
+      ".claude/hooks/rm-guard.js".source = ./hooks/rm-guard.js;
+      ".claude/hooks/rm-guard.sh" = {
+        executable = true;
+        text = ''
+          #!/bin/bash
+          # Fall through to normal permissions if node is unavailable.
+          command -v node >/dev/null 2>&1 || exit 0
+          exec node "${hooksDir}/rm-guard.js"
+        '';
+      };
     };
   };
 
@@ -468,6 +484,10 @@ in
             "gh pr checkout:*"
             "gh pr view:*"
             "gh pr diff:*"
+            # gh CLI replacements for denied GitHub MCP tools (issue_read, get_file_contents)
+            "gh issue view:*"
+            "gh issue list:*"
+            "gh api:*"
           ])
           ++ (toBashPermissions [
             "brew search:*"
@@ -511,7 +531,7 @@ in
             ++ gCalMcpReadTools
             ++ slackAiMcpReadTools
           ));
-        deny = [];
+        deny = githubMcpDenyTools;
         ask = toBashPermissions [
           # "git push:*"
           # "git rebase:*"
@@ -536,6 +556,16 @@ in
         ));
         defaultMode = "auto";
         additionalDirectories = [];
+      };
+      hooks = {
+        PreToolUse = [
+          {
+            matcher = "Bash";
+            hooks = [
+              { type = "command"; command = "${hooksDir}/rm-guard.sh"; }
+            ];
+          }
+        ];
       };
       statusLine = {
         type = "command";

--- a/nix/modules/home/hooks/rm-guard.js
+++ b/nix/modules/home/hooks/rm-guard.js
@@ -1,0 +1,246 @@
+// PreToolUse(Bash) hook: auto-approve `rm` only when every target is "safe":
+//   - under a temp dir (/tmp, /private/tmp, $TMPDIR, and the session scratchpad
+//     which lives under /private/tmp)
+//   - under <gitRoot>/tmp (project tmp/ subdir)
+//   - a git-tracked path in the current repo (recoverable via `git restore`)
+// Anything else (or any uncertainty) -> stay silent and let the normal
+// `ask rm:*` permission rule prompt. This hook never denies.
+"use strict";
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { execFileSync } = require("child_process");
+
+// Emit nothing and exit cleanly -> falls through to normal permission flow.
+function passThrough() {
+  process.exit(0);
+}
+
+function allow(reason) {
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "allow",
+        permissionDecisionReason: reason,
+      },
+    })
+  );
+  process.exit(0);
+}
+
+// Split a command line into tokens, honoring single/double quotes and
+// backslash escapes well enough for path operands.
+function tokenize(cmd) {
+  const tokens = [];
+  let cur = "";
+  let inTok = false;
+  let i = 0;
+  while (i < cmd.length) {
+    const c = cmd[i];
+    if (c === " " || c === "\t") {
+      if (inTok) {
+        tokens.push(cur);
+        cur = "";
+        inTok = false;
+      }
+      i++;
+      continue;
+    }
+    inTok = true;
+    if (c === '"' || c === "'") {
+      const q = c;
+      i++;
+      while (i < cmd.length && cmd[i] !== q) {
+        if (q === '"' && cmd[i] === "\\" && i + 1 < cmd.length) {
+          cur += cmd[i + 1];
+          i += 2;
+        } else {
+          cur += cmd[i];
+          i++;
+        }
+      }
+      i++; // closing quote
+      continue;
+    }
+    if (c === "\\" && i + 1 < cmd.length) {
+      cur += cmd[i + 1];
+      i += 2;
+      continue;
+    }
+    cur += c;
+    i++;
+  }
+  if (inTok) tokens.push(cur);
+  return tokens;
+}
+
+function real(p) {
+  try {
+    return fs.realpathSync(p);
+  } catch (_e) {
+    return p;
+  }
+}
+
+function isStrictlyUnder(abs, root) {
+  if (!root) return false;
+  return abs.startsWith(root + path.sep);
+}
+
+function main() {
+  let raw = "";
+  try {
+    raw = fs.readFileSync(0, "utf8");
+  } catch (_e) {
+    passThrough();
+  }
+
+  let data;
+  try {
+    data = JSON.parse(raw);
+  } catch (_e) {
+    passThrough();
+  }
+
+  const command = (data.tool_input && data.tool_input.command) || "";
+  const cwd = data.cwd || process.cwd();
+  if (!command) passThrough();
+
+  // Only handle a single, simple `rm` invocation. Bail on any shell control
+  // operators, redirects, substitutions, variables, or newlines so we never
+  // approve more than the rm we inspected.
+  if (/[;&|<>$\n`]/.test(command)) passThrough();
+
+  const tokens = tokenize(command);
+  if (!tokens.length) passThrough();
+  if (tokens[0] !== "rm" && tokens[0] !== "/bin/rm") passThrough();
+
+  // Separate flags from path operands (`--` ends flag parsing).
+  const operands = [];
+  let noMoreFlags = false;
+  for (let k = 1; k < tokens.length; k++) {
+    const t = tokens[k];
+    if (!noMoreFlags && t === "--") {
+      noMoreFlags = true;
+      continue;
+    }
+    if (!noMoreFlags && t.startsWith("-")) continue;
+    operands.push(t);
+  }
+  if (!operands.length) passThrough();
+
+  // Safe temp roots (raw + realpath'd, since /tmp -> /private/tmp on macOS).
+  const tmpRoots = ["/tmp", "/private/tmp"];
+  if (process.env.TMPDIR) tmpRoots.push(process.env.TMPDIR.replace(/\/$/, ""));
+  const safeRoots = new Set();
+  for (const r of tmpRoots) {
+    safeRoots.add(r);
+    safeRoots.add(real(r));
+  }
+
+  // Current repo root and its tmp/ subdir.
+  let repoRoot = null;
+  try {
+    repoRoot = execFileSync("git", ["-C", cwd, "rev-parse", "--show-toplevel"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch (_e) {
+    repoRoot = null;
+  }
+  if (repoRoot) {
+    const projTmp = path.join(repoRoot, "tmp");
+    safeRoots.add(projTmp);
+    safeRoots.add(real(projTmp));
+  }
+  const roots = Array.from(safeRoots).filter(Boolean);
+
+  function expandHome(p) {
+    if (p === "~") return os.homedir();
+    if (p.startsWith("~/")) return path.join(os.homedir(), p.slice(2));
+    return p;
+  }
+
+  function underTemp(abs) {
+    const r = real(abs);
+    return roots.some((root) => isStrictlyUnder(abs, root) || isStrictlyUnder(r, root));
+  }
+
+  // A target inside the repo is safe iff it is fully git-tracked (recoverable).
+  // Never approve deleting the repo root itself (would nuke .git history).
+  function gitTrackedSafe(abs) {
+    if (!repoRoot) return false;
+    if (abs === repoRoot) return false;
+    if (!isStrictlyUnder(abs, repoRoot)) return false;
+    const rel = path.relative(repoRoot, abs);
+
+    let stat = null;
+    try {
+      stat = fs.lstatSync(abs);
+    } catch (_e) {
+      stat = null;
+    }
+
+    if (stat && stat.isDirectory()) {
+      let tracked = "";
+      let others = "";
+      try {
+        tracked = execFileSync("git", ["-C", repoRoot, "ls-files", "--", rel], {
+          encoding: "utf8",
+        }).trim();
+        // No --exclude-standard: counts ignored files too, since `rm -rf` would
+        // delete those and they are not recoverable from git.
+        others = execFileSync("git", ["-C", repoRoot, "ls-files", "--others", "--", rel], {
+          encoding: "utf8",
+        }).trim();
+      } catch (_e) {
+        return false;
+      }
+      return tracked !== "" && others === "";
+    }
+
+    // File (or already-deleted path still in the index).
+    try {
+      execFileSync("git", ["-C", repoRoot, "ls-files", "--error-unmatch", "--", rel], {
+        stdio: "ignore",
+      });
+      return true;
+    } catch (_e) {
+      return false;
+    }
+  }
+
+  const globRe = /[*?[]/;
+
+  const allSafe = operands.every((op) => {
+    const expanded = expandHome(op);
+
+    if (globRe.test(expanded)) {
+      // Can't resolve globs (shell hasn't expanded them in the hook input).
+      // Only accept if the literal base dir before the glob is under a temp root.
+      const base = expanded.replace(/\/[^/]*[*?[].*$/, "");
+      if (!base || base === expanded) return false;
+      return underTemp(path.resolve(cwd, base));
+    }
+
+    const abs = path.resolve(cwd, expanded);
+    if (abs === "/" || abs === path.dirname(abs) && abs.length <= 1) return false;
+    if (underTemp(abs)) return true;
+    if (gitTrackedSafe(abs)) return true;
+    return false;
+  });
+
+  if (allSafe) {
+    allow("rm targets are temp files, project tmp/, or git-tracked (recoverable) paths");
+  }
+  passThrough();
+}
+
+try {
+  main();
+} catch (_e) {
+  // Never block on an internal error; fall through to normal permissions.
+  process.exit(0);
+}


### PR DESCRIPTION
## Summary

- Deny `issue_read`, `get_file_contents`, and `sub_issue_write` from the GitHub MCP plugin so those operations go through the `gh` CLI instead. Adds `gh issue view`/`gh issue list`/`gh api` allowances to cover the replacements.
- Add a `PreToolUse(Bash)` `rm-guard` hook that auto-approves `rm` only when **every** target is safe — under a temp dir (`/tmp`, `/private/tmp`, `$TMPDIR`, session scratchpad), under `<gitRoot>/tmp`, or git-tracked (recoverable via `git restore`). Anything else (or any uncertainty — compound commands, untracked files, the repo root, globs outside temp) falls through to the existing `ask rm:*` prompt. The hook never denies.
- Sync the generated global `~/.claude/CLAUDE.md` in `ai-globals.nix` to map each denied MCP tool to its `gh` CLI replacement.

## Notes

- `rm-guard.js` is written as a source file (not inlined in Nix) so it stays testable; verified against ~12 cases (temp files, scratchpad, `$TMPDIR`, project `tmp/`, tracked vs untracked, `--` separators, mixed safe/unsafe, repo root, non-`rm`).
- The hook only affects Claude Code sessions started after the rebuild.

## Test plan

- `nix eval nix/#darwinConfigurations.macbook_setup.system --apply 'x: "ok"'` passes.
- Apply with `nx up -hm`.