### PR TITLE
chore(packages): install livekit-cli via Homebrew, add uv

### DIFF
--- a/nix/modules/system/homebrew.nix
+++ b/nix/modules/system/homebrew.nix
@@ -10,6 +10,7 @@ let
 
   workOnlyBrews = [
     "just"
+    "livekit-cli"
     "memcached"
     "mysql@8.0"
     "pipenv"

--- a/nix/modules/system/packages.nix
+++ b/nix/modules/system/packages.nix
@@ -32,8 +32,6 @@ let
     awscli2
     graphviz
     librsvg
-    livekit-cli
-    portaudio
     pre-commit
     shared-mime-info
     xz

--- a/nix/modules/system/packages.nix
+++ b/nix/modules/system/packages.nix
@@ -21,6 +21,7 @@ let
     rsync
     shellcheck
     pay-respects
+    uv
     watchman
     yq
     zellij
@@ -31,6 +32,8 @@ let
     awscli2
     graphviz
     librsvg
+    livekit-cli
+    portaudio
     pre-commit
     shared-mime-info
     xz


### PR DESCRIPTION
## Summary
- Add `uv` to common Nix packages
- Install `livekit-cli` via Homebrew (work-only) instead of Nix
- `portaudio` is **not** declared anywhere — it comes in as a required dependency of the `livekit-cli` Homebrew formula

## Why Homebrew for livekit-cli?
`livekit-cli` 2.16.4 in nixpkgs-unstable fails to build: upstream recently switched to a git-submodule-vendored `portaudio`, which breaks the Nix build (stale `vendorHash` + missing include). The fix is pending upstream in [NixOS/nixpkgs#535005](https://github.com/NixOS/nixpkgs/pull/535005) (bumps to 2.16.6, uses nixpkgs `portaudio` + `pkg-config`).

Rather than carry a fragile overlay/vendorHash override until that merges, install via Homebrew, which already ships the working **2.16.6** bottle and resolves `portaudio` as a formula dependency. Homebrew's `brew bundle` cleanup never removes dependencies of listed formulae, so `--zap --force-cleanup` won't touch the transitively-installed `portaudio`.

## Test plan
- `nix eval nix/#darwinConfigurations.work_macbook.system --apply 'x: "ok"'` → `ok`
- `nx up` on the work machine installs `livekit-cli` (+ `portaudio` dep) via Homebrew