### PR TITLE
fix(zsh): pin starship prompt to stable profile path across rebuilds

### DIFF
--- a/nix/modules/home/zsh.nix
+++ b/nix/modules/home/zsh.nix
@@ -63,6 +63,22 @@ in
       # Add custom shell scripts to path
       export PATH=${config.home.homeDirectory}/.local/bin:${config.home.homeDirectory}/dotfiles/bin:$PATH
 
+      # Make the stable per-user profile outrank ~/.nix-profile in PATH.
+      # nix-darwin hardcodes ~/.nix-profile/bin ahead of /etc/profiles/per-user,
+      # but `nx up` churns the ~/.nix-profile generation during activation. Tools
+      # that bake an absolute binary path at shell-init time (e.g. starship's
+      # prompt) then keep calling a path that just disappeared and error on every
+      # redraw until the shell is restarted. Reordering pins those baked paths to
+      # the /etc/profiles symlink, which is repointed atomically across rebuilds.
+      # Runs before the starship init below so the bake picks up the new order.
+      () {
+        local hm="/etc/profiles/per-user/${config.home.username}/bin"
+        local np="$HOME/.nix-profile/bin"
+        path=("''${(@)path:#$np}")
+        path[''${path[(i)$hm]}]=("$hm" "$np")
+      }
+      typeset -U path PATH
+
       # Add custom completions to fpath
       fpath=(${config.home.homeDirectory}/dotfiles/completions $fpath)
 


### PR DESCRIPTION
## Problem

Intermittently, after running `nx up`, the current terminal's prompt starts spamming on every redraw:

```
zsh: no such file or directory: /Users/michaelmenanno/.nix-profile/bin/starship
```

The rebuild itself succeeds (`Configuration applied successfully!` prints first) — it's the *already-running* shell whose prompt breaks, and it stays broken until the terminal is restarted.

## Root cause

1. `starship init zsh` doesn't call `starship` by name — it bakes the **absolute path** of whatever `starship` resolved to at shell-startup into `PROMPT`/`RPROMPT`/`precmd`, and runs it on every prompt redraw.
2. nix-darwin's immutable `set-environment` hardcodes PATH as `$HOME/.nix-profile/bin:/etc/profiles/per-user/$USER/bin:...` — `~/.nix-profile/bin` is searched **first**. So a shell can bake either the stable `/etc/profiles/...` path or the fragile `~/.nix-profile/...` one, depending on profile state when that terminal opened.
3. `nx up` activation churns the `~/.nix-profile` generation (`Activating installPackages` → `uninstalling 'home-manager-path'`). starship actually lives in `/etc/profiles/per-user/...` (`useUserPackages = true`), so the baked `~/.nix-profile/bin/starship` path is left dangling → error on every redraw.

Intermittent because it only bites shells that baked the `~/.nix-profile` variant.

## Fix

Reorder PATH in `zsh.nix` `initContent` — which runs **before** the starship init — so `/etc/profiles/per-user/<user>/bin` outranks `~/.nix-profile/bin`. That symlink is repointed atomically across rebuilds and never deleted mid-session, so the baked path stays valid. Custom-script precedence (`.local/bin`, `dotfiles/bin`) is preserved; the reorder is idempotent.

## Verification

- Splice/reorder logic prototyped in `zsh -f` — confirmed correct ordering, preserved precedence, and idempotency.
- `nix eval nix/#darwinConfigurations.macbook_setup.system --apply 'x: "ok"'` → `ok`.
- `statix` and `deadnix` pass. (The unrelated pre-existing `nodePackages has been removed` flake-check failure at `nix/flake.nix:106` is out of scope.)

Will confirm end-to-end after an `nx up` on an affected terminal.