### PR TITLE
fix(system): expose Nix libvips and postgresql@17 to non-interactive shells

### DIFF
--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -24,11 +24,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782423922,
-        "narHash": "sha256-qPNd6lUohHP5gcJhqQ7rLV87RwIx0xYR2A4Frb9Zjc4=",
+        "lastModified": 1783024095,
+        "narHash": "sha256-oE+TNK98Pl7nHW4VU1oBvUKD5JR45U+py/NJmLoTNHI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5d320ab301cfaaca7d32514f13815d19d109f5f4",
+        "rev": "a4d410db95a6416d1008049330bd86b85b5db45a",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782030356,
-        "narHash": "sha256-h4WpMr455AfRub0FXBaon6Vcpe0waUyJ4GivIW6oyd4=",
+        "lastModified": 1783023993,
+        "narHash": "sha256-gaOvvY/lL1eWoSmSRO17pWry8R49AuPMrF4nzu47K5o=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "3017088b49efd404f78e3b104f553b97e4af786b",
+        "rev": "f8ed6cdcb1fd28a6ab7b61f4467a4f67fe2d9074",
         "type": "github"
       },
       "original": {
@@ -97,11 +97,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781607440,
-        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
+        "lastModified": 1782918843,
+        "narHash": "sha256-ETYnV9U7Sr+A45dohzZdfCZKOss4qrTkO+wgNZNvEc0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
+        "rev": "e8273b29fe1390ec8d4603f2477357555291432e",
         "type": "github"
       },
       "original": {

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -103,7 +103,7 @@
         packages = [
           pkgs.nixfmt
           pkgs.shellcheck
-          pkgs.nodePackages.markdownlint-cli2
+          pkgs.markdownlint-cli2
         ];
       };
 

--- a/nix/modules/home/zsh.nix
+++ b/nix/modules/home/zsh.nix
@@ -187,6 +187,10 @@ in
     fzf = {
       enable = true;
       enableZshIntegration = true;
+      # Atuin owns Ctrl-R (its integration is sourced after fzf's and reclaims the
+      # binding). Explicitly clear fzf's history widget so Home Manager doesn't warn
+      # about the Ctrl-R collision on every rebuild. Preserves current behaviour.
+      historyWidget.command = "";
     };
 
     zoxide = {

--- a/nix/modules/system/homebrew.nix
+++ b/nix/modules/system/homebrew.nix
@@ -161,6 +161,15 @@ in
     };
   };
 
+  # postgresql@17 is keg-only, so its client tools (psql, pg_dump) aren't on PATH.
+  # Add its stable Homebrew opt/bin declaratively instead of `brew link --force`
+  # (stateful, and conflicts with a future postgresql@18). Goes through
+  # environment.systemPath -> set-environment -> /etc/zshenv, so it also covers
+  # non-interactive shells. Personal-only: postgresql@17 is a personalOnlyBrews entry.
+  environment.systemPath = lib.optionals (!isWorkMachine) [
+    "/opt/homebrew/opt/postgresql@17/bin"
+  ];
+
   nix-homebrew = {
     enable = true;
     enableRosetta = true;

--- a/nix/modules/system/packages.nix
+++ b/nix/modules/system/packages.nix
@@ -56,7 +56,7 @@ let
     mediainfo
     pipx
     pmtiles
-    pnpm_9
+    pnpm_10
     pylint
     python3
     readline
@@ -91,6 +91,17 @@ in
       ln -sf "$f" /usr/local/lib/audacity/
     done
     echo "Audacity FFmpeg symlinks created in /usr/local/lib/audacity/"
+
+    # Expose Nix's libvips to ruby-vips, which dlopens libvips.42.dylib via FFI.
+    # SIP strips DYLD_FALLBACK_LIBRARY_PATH when Ruby's /usr/bin/env shebang execs,
+    # so we symlink into /usr/local/lib (an FFI default search dir, SIP-immune) and
+    # refresh it on every activation so it self-heals across libvips upgrades.
+    echo "Linking Nix libvips into /usr/local/lib for ruby-vips FFI..."
+    mkdir -p /usr/local/lib
+    for f in ${lib.getLib pkgs.vips}/lib/libvips*.dylib; do
+      ln -sf "$f" "/usr/local/lib/$(basename "$f")"
+    done
+    echo "Nix libvips symlinks created in /usr/local/lib/"
   '';
 
   environment.systemPackages = commonPackages ++ (if isWorkMachine then workOnlyPackages else personalOnlyPackages);


### PR DESCRIPTION
## Problem

Two host-environment papercuts that break in **non-interactive / background / spawned** shells — where `DYLD_*` env vars are SIP-stripped and my interactive `zsh.nix` PATH tweaks never run:

1. **ruby-vips can't find Nix libvips.** `ruby-vips` dlopens `libvips.42.dylib` via FFI. Works interactively, fails when a tool spawns `bin/rails test` without my profile. `DYLD_FALLBACK_LIBRARY_PATH` is unreliable because SIP strips it when Ruby's `/usr/bin/env` shebang execs. My temp fix was a hand-made `/opt/homebrew/lib` symlink pinned to a `/nix/store/<hash>` path that rots on every libvips upgrade.
2. **postgresql@17 client tools aren't on PATH.** It's keg-only, so `psql`/`pg_dump` are missing unless I prefix PATH. `brew link --force` is a stateful side-effect not captured in dotfiles and would conflict with a future `postgresql@18`.

## Fix

- **libvips** — activation script (`packages.nix`) refreshes symlinks into `/usr/local/lib` (an FFI default search dir, SIP-immune, already used by the Audacity block) on every rebuild, referencing the current vips `out` output via `lib.getLib`. Self-heals across upgrades; no version pinning. Personal-only, mirrors the existing FFmpeg-for-Audacity pattern.
- **postgresql@17** — add its stable Homebrew `opt/bin` to `environment.systemPath` (`homebrew.nix`). This flows through nix-darwin's `set-environment` → `/etc/zshenv`, which is read by **all** zsh invocations, so it covers non-interactive shells. Declarative, fresh-machine-reproducible, and migrating to 18 is a one-line edit.

## Fallout from the bundled `nx u` flake bump

The flake update advances nixpkgs/home-manager, which surfaced three unrelated breakages fixed here so the config activates cleanly:

- `pkgs.nodePackages` was removed upstream → devShell's `markdownlint-cli2` moves to top-level `pkgs` (unblocks `nx check`).
- `pnpm_9` (9.15.9) is now flagged insecure (2026 CVEs) → bump to `pnpm_10` (10.34.4).
- fzf's HM module now warns when a history manager also binds Ctrl-R. Atuin already owns Ctrl-R, so `programs.fzf.historyWidget.command = ""` makes that explicit (behavior unchanged).

## Verification

- `nx check` passes.
- `nx up` applied successfully on this machine.
- `/usr/local/lib/libvips*.dylib` symlinks point at the current vips store path.
- A clean non-interactive shell resolves both `psql` and `pg_dump`.
- No more Ctrl-R collision warning on rebuild.