### PR TITLE
feat(homebrew): skip Gatekeeper quarantine on cask installs

### DIFF
--- a/nix/modules/system/homebrew.nix
+++ b/nix/modules/system/homebrew.nix
@@ -137,6 +137,7 @@ in
 {
   homebrew = {
     enable = true;
+    caskArgs.no_quarantine = true;
     brews = commonBrews ++ (if isWorkMachine then workOnlyBrews else personalOnlyBrews);
     casks = commonCasks ++ (if isWorkMachine then workOnlyCasks else personalOnlyCasks);
     masApps = commonMasApps // (if isWorkMachine then {} else personalOnlyMasApps);


### PR DESCRIPTION
## Summary
- Add `homebrew.caskArgs.no_quarantine = true` so `brew bundle` passes `--no-quarantine` to all cask installs/upgrades declaratively — the Brewfile-wide equivalent of `HOMEBREW_CASK_OPTS="--no-quarantine"`.

## Notes
- Global to all casks (nix-darwin's string-list cask form has no per-cask override).
- Only affects future installs/upgrades; already-quarantined apps stay so until re-installed.

## Test plan
- [x] `nix eval nix/#darwinConfigurations.macbook_setup.system --apply 'x: "ok"'` passes