### PR TITLE
fix(nx): pin 1Password account when loading secrets

### DIFF
--- a/bin/nixup-with-secrets
+++ b/bin/nixup-with-secrets
@@ -117,17 +117,22 @@ load_secrets() {
 
     print_status "Loading secrets from 1Password..."
 
+    # The Nix vault lives in the personal account. With a second (work) account
+    # signed in, bare `op item get` resolves against the wrong account and fails
+    # ("isn't a vault in this account"). Pin the account explicitly.
+    local op_account="${NIX_OP_ACCOUNT:-my.1password.com}"
+
     # Fetch all items in parallel for efficiency
     local main_id_json server_json private_id_json ssh_json git_config_json github_json
 
     print_status "Fetching 1Password items..."
-    main_id_json="$(op item get "MainID" --vault="Nix" --format=json 2>/dev/null || echo '{}')"
-    server_json="$(op item get "Server" --vault="Nix" --format=json 2>/dev/null || echo '{}')"
-    private_id_json="$(op item get "PrivateID" --vault="Nix" --format=json 2>/dev/null || echo '{}')"
-    ssh_json="$(op item get "SSH" --vault="Nix" --format=json 2>/dev/null || echo '{}')"
-    git_config_json="$(op item get "Git Config" --vault="Nix" --format=json 2>/dev/null || echo '{}')"
-    github_json="$(op item get "Github" --vault="Nix" --format=json 2>/dev/null || echo '{}')"
-    work_json="$(op item get "Work" --vault="Nix" --format=json 2>/dev/null || echo '{}')"
+    main_id_json="$(op item get "MainID" --vault="Nix" --account="$op_account" --format=json 2>/dev/null || echo '{}')"
+    server_json="$(op item get "Server" --vault="Nix" --account="$op_account" --format=json 2>/dev/null || echo '{}')"
+    private_id_json="$(op item get "PrivateID" --vault="Nix" --account="$op_account" --format=json 2>/dev/null || echo '{}')"
+    ssh_json="$(op item get "SSH" --vault="Nix" --account="$op_account" --format=json 2>/dev/null || echo '{}')"
+    git_config_json="$(op item get "Git Config" --vault="Nix" --account="$op_account" --format=json 2>/dev/null || echo '{}')"
+    github_json="$(op item get "Github" --vault="Nix" --account="$op_account" --format=json 2>/dev/null || echo '{}')"
+    work_json="$(op item get "Work" --vault="Nix" --account="$op_account" --format=json 2>/dev/null || echo '{}')"
 
     # Process secrets with optimized JSON parsing
 


### PR DESCRIPTION
## Problem

`nx up` failed with **"Loaded 0/33 secrets from 1Password"** and reported every item as missing — even though all items were present and correct.

The real cause: a second **work** 1Password account (`babylist.1password.com`) is now signed in alongside the personal one. The `Nix` vault lives in the **personal** account, but `load_secrets` called `op item get "MainID" --vault="Nix"` **without `--account`**, so `op` resolved the calls against the work account:

```
[ERROR] "Nix" isn't a vault in this account. Specify the vault with its ID or name.
```

Because the calls suppress stderr (`2>/dev/null || echo '{}'`), each item silently became `{}` and all 33 fields parsed as empty.

## Fix

Pin the account explicitly on all seven `op item get` calls via `--account="$op_account"`, defaulting to `my.1password.com` (the personal account holding the `Nix` vault) and overridable with `NIX_OP_ACCOUNT`.

## Testing

Verified all seven items now fetch correctly with the account pinned:

```
MainID -> 12 fields (github_email, github_user, signing_key, …)
Server -> 10   PrivateID -> 11   SSH -> 4
Git Config -> 4   Github -> 5   Work -> 6
```