### PR TITLE
Unbreak nx up after the flake input update

### DIFF
--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -3,16 +3,33 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1784068757,
-        "narHash": "sha256-7KnV7rTlMpys+2J+TFVxUDDyKPLXFs4wIMtckMC72VM=",
+        "lastModified": 1785146564,
+        "narHash": "sha256-Sa7/HrfB04H32OJ7/ofxXjiZEbkWtCNOriONYYTL1OA=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "6bd951d96e7ebc54787799dba77bfb26ec956c4c",
+        "rev": "b2cfc03346d482f79886de108fee5dc49a6efc10",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "6.0.11",
+        "ref": "6.0.13",
+        "repo": "brew",
+        "type": "github"
+      }
+    },
+    "brew-src_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1784558651,
+        "narHash": "sha256-woXJ1ATKpSYRWCy46TQJjmm9XzAeZVEZw9xDfVG9NYI=",
+        "owner": "Homebrew",
+        "repo": "brew",
+        "rev": "b48c7994b5f0eed7bef532efa63cb4e4f763887a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Homebrew",
+        "ref": "6.0.12",
         "repo": "brew",
         "type": "github"
       }
@@ -24,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784351324,
-        "narHash": "sha256-By+kuRJZRqs2TuXgtR8vJ8cTKWXw33YG/Yollu5cO1U=",
+        "lastModified": 1785306346,
+        "narHash": "sha256-DScBkW0fOgpGPK2trNoX3ryLTlaC14+gglFo/BhGJ4g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "460108009ca1ff69ca2ff19079ca2c838d6e3080",
+        "rev": "e705714e918c3b11affcdd15db2cbe3a070420a0",
         "type": "github"
       },
       "original": {
@@ -44,11 +61,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781761792,
-        "narHash": "sha256-rCPytmKNjctLloB6UgK5CRrHSwV4b0ygxtJLPPp8R14=",
+        "lastModified": 1784500460,
+        "narHash": "sha256-UvORnAxTRHax7RG74W8Z2t4GvIkX6AjJ5kk0QlwZomo=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "a1fa429e945becaf60468600daf649be4ba0350c",
+        "rev": "57a3171f94705599a2499248ca5758d5eb47c0e0",
         "type": "github"
       },
       "original": {
@@ -59,14 +76,14 @@
     },
     "nix-homebrew": {
       "inputs": {
-        "brew-src": "brew-src"
+        "brew-src": "brew-src_2"
       },
       "locked": {
-        "lastModified": 1784159664,
-        "narHash": "sha256-I/B6YoRLImHEqNWh8bs+tPjEDeteACeFhcLyoSMo1GE=",
+        "lastModified": 1784906761,
+        "narHash": "sha256-2v0H8+Ert+xbm0oliHblXTPPczuKiibBUBvRax59kxg=",
         "owner": "zhaofengli-wip",
         "repo": "nix-homebrew",
-        "rev": "842eeb863ecca0eeb463f7a814cdc51e1d925776",
+        "rev": "60623ec512406261f553d24033c8a0c53fd0b7f2",
         "type": "github"
       },
       "original": {
@@ -82,11 +99,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783864904,
-        "narHash": "sha256-BQxN5UMg9FOevAsgBRwPxfxlh51Puj+dNn/8Dsi3sPM=",
+        "lastModified": 1785046085,
+        "narHash": "sha256-UiK+mmZJuLWQVhJ5b2wDzogIYWAesyRm6LA3h3Ulh3Y=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "1111b9bc836afb7e31a7014e8d1272de9b1c917d",
+        "rev": "11665045df8b9938ef811a3bfdc65cffb02b4b70",
         "type": "github"
       },
       "original": {
@@ -97,11 +114,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782918843,
-        "narHash": "sha256-ETYnV9U7Sr+A45dohzZdfCZKOss4qrTkO+wgNZNvEc0=",
+        "lastModified": 1785301185,
+        "narHash": "sha256-eoS3KQTO0aPWXZvIaRbRAzSSHW3l5wdMFXtT1ISfoKA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e8273b29fe1390ec8d4603f2477357555291432e",
+        "rev": "9bc02893134c733dd85de46ee4fb2fac696b5529",
         "type": "github"
       },
       "original": {
@@ -129,6 +146,7 @@
     },
     "root": {
       "inputs": {
+        "brew-src": "brew-src",
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
         "nix-homebrew": "nix-homebrew",

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -11,6 +11,13 @@
 
     nix-homebrew.url = "github:zhaofengli-wip/nix-homebrew";
 
+    # Pinned ahead of nix-homebrew's own brew-src (6.0.12). See the `package`
+    # override in modules/system/homebrew.nix for why.
+    brew-src = {
+      url = "github:Homebrew/brew/6.0.13";
+      flake = false;
+    };
+
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/nix/modules/default.nix
+++ b/nix/modules/default.nix
@@ -2,6 +2,7 @@
   # System (nix-darwin) modules: OS, apps, services, defaults
   systemModules = [
     ./system/base-configuration.nix
+    ./system/overlays.nix
     ./system/packages.nix
     ./system/homebrew.nix
     ./system/pwa-apps.nix
@@ -43,6 +44,7 @@
   # Work machine system modules (excludes personal apps/services)
   workSystemModules = [
     ./system/base-configuration.nix
+    ./system/overlays.nix
     ./system/packages.nix
     ./system/homebrew.nix
     ./system/system-defaults.nix

--- a/nix/modules/home/claude.nix
+++ b/nix/modules/home/claude.nix
@@ -572,9 +572,9 @@ in
         command = "${hooksDir}/statusline.sh";
       };
       enabledPlugins = {
-        "claude-code-setup@claude-plugins-official" = true;
+        "claude-code-setup@claude-plugins-official" = false;
         "claude-md-management@claude-plugins-official" = true;
-        "code-simplifier@claude-plugins-official" = true;
+        "code-simplifier@claude-plugins-official" = false;
         "commit-commands@claude-plugins-official" = true;
         "frontend-design@claude-plugins-official" = true;
         "github@claude-plugins-official" = true;
@@ -584,22 +584,19 @@ in
         "superpowers@claude-plugins-official" = true;
         "security-guidance@claude-plugins-official" = true;
         "gopls-lsp@claude-plugins-official" = true;
-        "csharp-lsp@claude-plugins-official" = true;
+        "csharp-lsp@claude-plugins-official" = false;
         "rust-analyzer-lsp@claude-plugins-official" = true;
-        "php-lsp@claude-plugins-official" = true;
-        "jdtls-lsp@claude-plugins-official" = true;
-        "clangd-lsp@claude-plugins-official" = true;
-        "swift-lsp@claude-plugins-official" = true;
-        "kotlin-lsp@claude-plugins-official" = true;
-        "lua-lsp@claude-plugins-official" = true;
+        "php-lsp@claude-plugins-official" = false;
+        "jdtls-lsp@claude-plugins-official" = false;
+        "clangd-lsp@claude-plugins-official" = false;
+        "swift-lsp@claude-plugins-official" = false;
+        "kotlin-lsp@claude-plugins-official" = false;
+        "lua-lsp@claude-plugins-official" = false;
         "ruby-lsp@claude-plugins-official" = true;
         "typescript-lsp@claude-plugins-official" = true;
         "notion-markdown@babylist" = isWorkMachine;
         "datadog-analytics@babylist" = isWorkMachine;
         "skill-creator@claude-plugins-official" = false;
-
-        # Local plugins
-        "gwa@local-plugins" = !isWorkMachine;
       };
       extraKnownMarketplaces = lib.optionalAttrs isWorkMachine {
         babylist = {

--- a/nix/modules/system/homebrew.nix
+++ b/nix/modules/system/homebrew.nix
@@ -1,4 +1,4 @@
-{ config, lib, username, isWorkMachine ? false, ... }:
+{ config, lib, username, inputs, isWorkMachine ? false, ... }:
 let
   commonBrews = [
     "coreutils"
@@ -177,6 +177,18 @@ in
     enableRosetta = true;
     user = username;
     autoMigrate = true;
+
+    # Homebrew serves cask definitions from its live JSON API, but nix pins brew
+    # itself, so a brand-new cask stanza breaks the pinned release. brew 6.0.12
+    # (nix-homebrew's pin) has no `command_wrapper` artifact, which the API now
+    # ships for firefox and vlc, so `brew bundle` aborts with "undefined method
+    # 'command_wrapper'". 6.0.13 adds it. nix-homebrew embeds `version` as
+    # HOMEBREW_VERSION, so it has to match the source it is built from. Drop this
+    # once nix-homebrew bumps brew-src past 6.0.12.
+    package = inputs.brew-src // {
+      name = "brew-6.0.13";
+      version = "6.0.13";
+    };
   };
 
   # Homebrew 6.0 (June 2026) requires third-party taps to be explicitly trusted

--- a/nix/modules/system/overlays.nix
+++ b/nix/modules/system/overlays.nix
@@ -1,0 +1,17 @@
+_:
+
+{
+  nixpkgs.overlays = [
+    (_final: prev: {
+      # pytest 9.1 treats a trailing comma in `parametrize` argnames as
+      # tuple-style, so pipx 1.14.0's tests/test_inject.py fails at collection.
+      # nixpkgs already deselects every test in that file via its "inject"
+      # disabledTests entry (they need network), but `-k` filters after
+      # collection, so only a pre-collection ignore avoids the error. Fixed
+      # upstream after 1.14.0; drop this once nixpkgs ships that release.
+      pipx = prev.pipx.overridePythonAttrs (old: {
+        disabledTestPaths = (old.disabledTestPaths or [ ]) ++ [ "tests/test_inject.py" ];
+      });
+    })
+  ];
+}


### PR DESCRIPTION
`nx u` bumped the flake inputs and `nx up` then failed twice, in two unrelated places. Neither is a config bug; both are upstream skew that the input update exposed. This updates the lock and works around both.

## 1. pipx build failure (nixpkgs bump: pytest 9.0.3 -> 9.1.1)

pytest 9.1 added trailing-comma handling to `parametrize` (implementing pytest#719): `"arg,"` now means tuple-style, so argvalues are no longer wrapped. pipx 1.14.0's `tests/test_inject.py:13` writes `@pytest.mark.parametrize("pkg_spec,", [...])` with a trailing comma but bare strings as values, so `"black==22.8.0"` gets unpacked as 13 characters against 1 name and the build dies at collection.

nixpkgs already deselects every test in that file (they need network), but `-k` filters *after* collection, so the deselect cannot prevent a collection-time error. New `nix/modules/system/overlays.nix` moves the exclusion to a pre-collection `--ignore` via `disabledTestPaths`.

Zero coverage lost: all five tests in the file are named `test_inject_*`, so they already matched the existing `not (inject)` deselect. Build log reports `165 passed, 7 skipped` both before and after, just without the 10 collection errors.

Fixed upstream after pipx 1.14.0 (the trailing comma is gone on main), just not in the tag nixpkgs pins. Drop the overlay once nixpkgs ships that release.

Patching the source instead was rejected: a second site (`"with_packages,"`) has an `()` value that is genuinely invalid under the new semantics, and a third (`"with_suffix,"`) uses the trailing comma *correctly*, so it would have meant guessing at upstream's refactor.

## 2. brew bundle failure (nix-homebrew bump: brew 6.0.11 -> 6.0.12)

```
Error: Cask 'firefox' definition is invalid: undefined method 'command_wrapper' for Cask 'firefox'
`brew bundle` failed! Failed to fetch firefox, vlc
```

Homebrew 4+ does not clone the cask tap (`brew config` reports `Core cask tap: N/A`) and reads cask definitions from the live JSON API, but nix pins brew itself. So when Homebrew adds a new Cask DSL stanza and casks start using it, the pinned release cannot parse it. The API payload now carries `[":command_wrapper", ...]` for firefox 153.0.1 and vlc 3.0.23, and `command_wrapper` does not exist anywhere in brew 6.0.12.

Verified against the tags: `6.0.12` has no `Library/Homebrew/cask/artifact/command_wrapper.rb`; `6.0.13` has it. nix-homebrew upstream is still pinned to 6.0.12 (its latest commit is the one already locked here), so a flake update does not help. This adds a `brew-src` input pinned to 6.0.13 and overrides `nix-homebrew.package`.

`version` is not cosmetic: nix-homebrew seds it into `brew.sh` as `HOMEBREW_VERSION`, so it has to match the source. Drop the override once nix-homebrew bumps its own pin past 6.0.12.

`nix-homebrew`'s own `brew-src` stays in the lock as `brew-src_2`. I deliberately did not add `inputs.nix-homebrew.inputs.brew-src.follows`: the `package` override bypasses it anyway, and a `follows` would mean that dropping the override later silently yields 6.0.13 source labelled 6.0.12, since nix-homebrew derives its version string from its own `flake.lock` rather than the input.

## Also included

Second commit disables unused Claude Code plugins and removes the local `gwa` plugin plus its now-unreferenced marketplace.

## Verification

- pipx builds from this config; `pipx --version` -> 1.14.0
- resolved brew package is `version=6.0.13`, and that store path contains `command_wrapper.rb` with `require "cask/artifact/command_wrapper"` registered in `artifact.rb`
- both `macbook_setup` and `work_macbook` evaluate to a drvPath
- statix and deadnix pass over `nix/`

Not yet run end to end: `nx up` itself needs interactive 1Password and Touch ID, so the activation run is still to be done.
