### PR TITLE
chore(nix): update flake inputs and drop the brew-src override

### DIFF
--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -17,23 +17,6 @@
         "type": "github"
       }
     },
-    "brew-src_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1784558651,
-        "narHash": "sha256-woXJ1ATKpSYRWCy46TQJjmm9XzAeZVEZw9xDfVG9NYI=",
-        "owner": "Homebrew",
-        "repo": "brew",
-        "rev": "b48c7994b5f0eed7bef532efa63cb4e4f763887a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Homebrew",
-        "ref": "6.0.12",
-        "repo": "brew",
-        "type": "github"
-      }
-    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -41,11 +24,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785306346,
-        "narHash": "sha256-DScBkW0fOgpGPK2trNoX3ryLTlaC14+gglFo/BhGJ4g=",
+        "lastModified": 1785531816,
+        "narHash": "sha256-vkMnV0JIyw+g/NmcfoajlGaAO+9a0ezia+FZohQJrik=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e705714e918c3b11affcdd15db2cbe3a070420a0",
+        "rev": "bf9ce9fec78f95f374e8dd3b503863a3ec128ebe",
         "type": "github"
       },
       "original": {
@@ -61,11 +44,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784500460,
-        "narHash": "sha256-UvORnAxTRHax7RG74W8Z2t4GvIkX6AjJ5kk0QlwZomo=",
+        "lastModified": 1785389976,
+        "narHash": "sha256-0tLW8Ff5yt8AH97jw4ZpFJ0OCJ122zIlgWGDmOfU/VU=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "57a3171f94705599a2499248ca5758d5eb47c0e0",
+        "rev": "15abb8c98f336cd8bd840d71059adebabe60bf04",
         "type": "github"
       },
       "original": {
@@ -76,14 +59,14 @@
     },
     "nix-homebrew": {
       "inputs": {
-        "brew-src": "brew-src_2"
+        "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1784906761,
-        "narHash": "sha256-2v0H8+Ert+xbm0oliHblXTPPczuKiibBUBvRax59kxg=",
+        "lastModified": 1785544760,
+        "narHash": "sha256-qV6OoNuly4ntqpCg7esIeJjUboxSnQNlLPxz+y5h9/o=",
         "owner": "zhaofengli-wip",
         "repo": "nix-homebrew",
-        "rev": "60623ec512406261f553d24033c8a0c53fd0b7f2",
+        "rev": "937ce52c7d046310571f3a070713804ead496843",
         "type": "github"
       },
       "original": {
@@ -114,11 +97,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785301185,
-        "narHash": "sha256-eoS3KQTO0aPWXZvIaRbRAzSSHW3l5wdMFXtT1ISfoKA=",
+        "lastModified": 1785483748,
+        "narHash": "sha256-M4HXpLsR7iFTNQfD/q+zK8/QeRYztYVDVIdIgCVGGZ0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9bc02893134c733dd85de46ee4fb2fac696b5529",
+        "rev": "59ea0b1c043c463e39fcb3cfb9a5c8bcf0777c72",
         "type": "github"
       },
       "original": {
@@ -146,7 +129,6 @@
     },
     "root": {
       "inputs": {
-        "brew-src": "brew-src",
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
         "nix-homebrew": "nix-homebrew",

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -11,13 +11,6 @@
 
     nix-homebrew.url = "github:zhaofengli-wip/nix-homebrew";
 
-    # Pinned ahead of nix-homebrew's own brew-src (6.0.12). See the `package`
-    # override in modules/system/homebrew.nix for why.
-    brew-src = {
-      url = "github:Homebrew/brew/6.0.13";
-      flake = false;
-    };
-
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/nix/modules/system/homebrew.nix
+++ b/nix/modules/system/homebrew.nix
@@ -1,4 +1,4 @@
-{ config, lib, username, inputs, isWorkMachine ? false, ... }:
+{ config, lib, username, isWorkMachine ? false, ... }:
 let
   commonBrews = [
     "coreutils"
@@ -177,18 +177,6 @@ in
     enableRosetta = true;
     user = username;
     autoMigrate = true;
-
-    # Homebrew serves cask definitions from its live JSON API, but nix pins brew
-    # itself, so a brand-new cask stanza breaks the pinned release. brew 6.0.12
-    # (nix-homebrew's pin) has no `command_wrapper` artifact, which the API now
-    # ships for firefox and vlc, so `brew bundle` aborts with "undefined method
-    # 'command_wrapper'". 6.0.13 adds it. nix-homebrew embeds `version` as
-    # HOMEBREW_VERSION, so it has to match the source it is built from. Drop this
-    # once nix-homebrew bumps brew-src past 6.0.12.
-    package = inputs.brew-src // {
-      name = "brew-6.0.13";
-      version = "6.0.13";
-    };
   };
 
   # Homebrew 6.0 (June 2026) requires third-party taps to be explicitly trusted


### PR DESCRIPTION
## Summary

Updates the flake inputs and removes the `brew-src` override added in 333eeb0, which is now redundant.

nix-homebrew merged `brew-src: 6.0.12 -> 6.0.13` ([#164](https://github.com/zhaofengli-wip/nix-homebrew/pull/164)) — that is exactly the version the override was pinning ahead to. After the input update both lock nodes resolve to the same rev:

```
brew-src    6.0.13  b2cfc03…   (our override)
brew-src_2  6.0.13  b2cfc03…   (nix-homebrew's own)
```

nix-homebrew's default also sets the same `name`/`version` attrs the override was setting, so it had become a literal no-op. This removes:

- the root `brew-src` input in `nix/flake.nix`
- the `nix-homebrew.package` override in `nix/modules/system/homebrew.nix`
- the now-unused `inputs` module arg (deadnix would flag it otherwise)

Post-removal, brew still resolves to `brew-6.0.13` at `/nix/store/rpp9rqv9c9ygznpc5b49v9z6cmbzrma7-source` — the same brew that was already running.

## What is NOT removed

The **pipx overlay** in `overlays.nix` stays. nixpkgs is still on pipx **1.14.0**, the exact release whose `tests/test_inject.py` fails at collection under pytest 9.1. Upstream fixed it (now at 1.16.5) but it has not landed in nixpkgs, so dropping the overlay would break the build again.

## Input updates

| Input | From | To |
|---|---|---|
| nixpkgs | `9bc0289` | `59ea0b1` |
| nix-darwin | `57a3171` | `15abb8c` |
| home-manager | `e705714` | `bf9ce9f` |
| nix-homebrew | `60623ec` | `937ce52` |

## Test plan

- [x] `nix eval` succeeds for both `macbook_setup` and `work_macbook`
- [x] `nx lint` passes all three stages (flake eval, statix, deadnix)
- [x] `nx up` applied cleanly on the personal machine, Homebrew bundle included
- [ ] Not exercised on a work machine

## Note

brew 6.0.14 is already out and nix-homebrew is not on it yet. This class of breakage recurs whenever the cask JSON API ships a stanza newer than the pinned brew, so the override may need to come back at some point — but carrying a no-op now provides no protection against that.