### PR TITLE
Add gh-stack declaratively, fix pipx overlay gap for -hm builds

### DIFF
--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -17,6 +17,22 @@
         "type": "github"
       }
     },
+    "gh-stack": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1785805944,
+        "narHash": "sha256-SBP6z6G35wGY31RMhPpsZ1QDOhmVBlLv7ktLXIA3HwI=",
+        "owner": "github",
+        "repo": "gh-stack",
+        "rev": "14fc42ed9b6c376a53b2f999f138d3bd26dac546",
+        "type": "github"
+      },
+      "original": {
+        "owner": "github",
+        "repo": "gh-stack",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -129,6 +145,7 @@
     },
     "root": {
       "inputs": {
+        "gh-stack": "gh-stack",
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
         "nix-homebrew": "nix-homebrew",

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -25,6 +25,11 @@
       url = "github:mmenanno/ralph-claude-code";
       flake = false;
     };
+
+    gh-stack = {
+      url = "github:github/gh-stack";
+      flake = false;
+    };
   };
 
   outputs = inputs@{ self, nix-darwin, nixpkgs, nix-homebrew, home-manager, ... }:
@@ -34,6 +39,12 @@
       inherit (lib) getEnvOrFallback;
 
       moduleIndex = import ./modules/default.nix;
+
+      # Standalone home-manager builds (`nx up -hm`) don't go through the
+      # nix-darwin system pkgs, so they need the same overlays applied directly.
+      overlaidPkgs = nixpkgs.legacyPackages.aarch64-darwin.extend (
+        nixpkgs.lib.composeManyExtensions (import ./overlays.nix)
+      );
 
       # Environment-based username with fallback using consistent pattern
       username = getEnvOrFallback "NIX_FULL_NAME" "bootstrap-user" "placeholder-user";
@@ -108,7 +119,7 @@
       };
 
     homeConfigurations."default" = home-manager.lib.homeManagerConfiguration {
-      pkgs = nixpkgs.legacyPackages.aarch64-darwin;
+      pkgs = overlaidPkgs;
       extraSpecialArgs = commonConfig // { dotlib = lib; };
       modules = [
         ./home.nix
@@ -117,7 +128,7 @@
     };
 
     homeConfigurations."work" = home-manager.lib.homeManagerConfiguration {
-      pkgs = nixpkgs.legacyPackages.aarch64-darwin;
+      pkgs = overlaidPkgs;
       extraSpecialArgs = commonConfig // { dotlib = lib; isWorkMachine = true; };
       modules = [
         ./home.nix

--- a/nix/modules/default.nix
+++ b/nix/modules/default.nix
@@ -70,6 +70,7 @@
     ./home/mcp-shared.nix
     ./home/gh.nix
     ./home/claude.nix
+    ./home/claude-skills.nix
     ./home/ide-extensions.nix
     ./home/npmrc.nix
     ./home/rostrum.nix

--- a/nix/modules/home/claude-skills.nix
+++ b/nix/modules/home/claude-skills.nix
@@ -1,7 +1,8 @@
-{ inputs, ... }:
+{ inputs, lib, isWorkMachine ? false, ... }:
 
 let
   ralphClaudeCode = inputs.ralph-claude-code;
+  ghStack = inputs.gh-stack;
 
   ralphSkills = {
     ".claude/skills/brief".source = "${ralphClaudeCode}/skill/brief";
@@ -14,6 +15,10 @@ let
     };
   };
 
+  ghStackSkill = {
+    ".claude/skills/gh-stack".source = "${ghStack}/skills/gh-stack";
+  };
+
 in {
-  home.file = ralphSkills // ralphScript;
+  home.file = ghStackSkill // lib.optionalAttrs (!isWorkMachine) (ralphSkills // ralphScript);
 }

--- a/nix/modules/home/claude.nix
+++ b/nix/modules/home/claude.nix
@@ -596,6 +596,11 @@ in
         "typescript-lsp@claude-plugins-official" = true;
         "notion-markdown@babylist" = isWorkMachine;
         "datadog-analytics@babylist" = isWorkMachine;
+        "avo@babylist" = isWorkMachine;
+        "context-tools@babylist" = isWorkMachine;
+        "datadog@babylist" = isWorkMachine;
+        "fight-me@babylist" = isWorkMachine;
+        "preflight-review@babylist" = isWorkMachine;
         "skill-creator@claude-plugins-official" = false;
       };
       extraKnownMarketplaces = lib.optionalAttrs isWorkMachine {

--- a/nix/modules/home/gh.nix
+++ b/nix/modules/home/gh.nix
@@ -19,6 +19,7 @@ in
       git_protocol = "ssh";
       prompt = "enabled";
     };
+    extensions = [ pkgs.gh-stack ];
   };
 
   # Persist gh CLI auth from the 1Password-sourced token into ~/.config/gh/hosts.yml.

--- a/nix/modules/system/homebrew.nix
+++ b/nix/modules/system/homebrew.nix
@@ -53,7 +53,6 @@ let
   ];
 
   workOnlyCasks = [
-    "gather"
     "grammarly-desktop"
     "linear"
     "meetingbar"

--- a/nix/modules/system/homebrew.nix
+++ b/nix/modules/system/homebrew.nix
@@ -113,6 +113,10 @@ let
     "Tampermonkey" = 6738342400;
   };
 
+  # Third-party taps that need explicit trust under Homebrew 6.0 (see
+  # system.activationScripts.preActivation below).
+  trustedTaps = [ "dotenvx/brew" ] ++ (if isWorkMachine then [ "puma/puma" ] else [ ]);
+
   personalOnlyMasApps = {
     "Cookie-Editor" = 6446215341;
     "Deliveries" = 290986013;
@@ -173,16 +177,18 @@ in
   # Homebrew 6.0 (June 2026) requires third-party taps to be explicitly trusted
   # before `brew bundle` will load their formulae/casks. nix-darwin has no
   # declarative trust option yet (tracked in nix-darwin#1794, PR nix-darwin#1789
-  # adds `homebrew.brews.*.trusted`), so we trust the dotenvx tap here. This runs
+  # adds `homebrew.brews.*.trusted`), so we trust third-party taps here. This runs
   # in `preActivation`, which executes before the homebrew bundle step, and
   # mirrors the bundle's own `sudo --user --set-home` invocation so both resolve
   # the same trust store (~/.homebrew/trust.json; XDG_CONFIG_HOME is not
   # preserved through sudo). Idempotent — remove once PR #1789 lands and switch
-  # the dotenvx brew entry to `{ name = "dotenvx/brew/dotenvx"; trusted = true; }`.
+  # the relevant brew entries to `{ name = "..."; trusted = true; }`.
   system.activationScripts.preActivation.text = lib.mkAfter ''
     if [ -x ${config.homebrew.prefix}/bin/brew ]; then
-      sudo --user=${lib.escapeShellArg username} --set-home \
-        ${config.homebrew.prefix}/bin/brew trust --tap dotenvx/brew >/dev/null 2>&1 || true
+      ${lib.concatMapStringsSep "\n" (tap: ''
+        sudo --user=${lib.escapeShellArg username} --set-home \
+          ${config.homebrew.prefix}/bin/brew trust --tap ${lib.escapeShellArg tap} >/dev/null 2>&1 || true
+      '') trustedTaps}
     fi
   '';
 }

--- a/nix/modules/system/overlays.nix
+++ b/nix/modules/system/overlays.nix
@@ -1,17 +1,5 @@
 _:
 
 {
-  nixpkgs.overlays = [
-    (_final: prev: {
-      # pytest 9.1 treats a trailing comma in `parametrize` argnames as
-      # tuple-style, so pipx 1.14.0's tests/test_inject.py fails at collection.
-      # nixpkgs already deselects every test in that file via its "inject"
-      # disabledTests entry (they need network), but `-k` filters after
-      # collection, so only a pre-collection ignore avoids the error. Fixed
-      # upstream after 1.14.0; drop this once nixpkgs ships that release.
-      pipx = prev.pipx.overridePythonAttrs (old: {
-        disabledTestPaths = (old.disabledTestPaths or [ ]) ++ [ "tests/test_inject.py" ];
-      });
-    })
-  ];
+  nixpkgs.overlays = import ../../overlays.nix;
 }

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -1,0 +1,13 @@
+[
+  (_final: prev: {
+    # pytest 9.1 treats a trailing comma in `parametrize` argnames as
+    # tuple-style, so pipx 1.14.0's tests/test_inject.py fails at collection.
+    # nixpkgs already deselects every test in that file via its "inject"
+    # disabledTests entry (they need network), but `-k` filters after
+    # collection, so only a pre-collection ignore avoids the error. Fixed
+    # upstream after 1.14.0; drop this once nixpkgs ships that release.
+    pipx = prev.pipx.overridePythonAttrs (old: {
+      disabledTestPaths = (old.disabledTestPaths or [ ]) ++ [ "tests/test_inject.py" ];
+    });
+  })
+]


### PR DESCRIPTION
## Summary
- `programs.gh.extensions = [ pkgs.gh-stack ]` installs the `gh-stack` CLI extension declaratively instead of via manual `gh extension install`.
- New `gh-stack` flake input symlinks the repo's bundled Claude Code skill into `~/.claude/skills/gh-stack`, shared between personal and work machines (`claude-skills.nix` now takes `isWorkMachine` so the `ralph` skill stays personal-only while `gh-stack` is shared, and the module is now wired into `workHomeModules`).
- Extracted the pipx test-collection overlay into `nix/overlays.nix` and applied it to the standalone `homeConfigurations` pkgs — `nx up -hm` builds pkgs straight from `nixpkgs.legacyPackages` and never picked up the overlay that full `darwin-rebuild switch` gets via `nixpkgs.overlays`, so `-hm` builds broke on pipx's `test_inject.py` collection error.
- Also includes unrelated pre-staged changes: new work-only Claude Code plugins (avo, context-tools, datadog, fight-me, preflight-review) and dropping the `gather` cask from `workOnlyCasks`.

## Test plan
- [x] `nx check` passes
- [x] `nx up -hm` applies cleanly on this (work) machine
- [x] `gh stack --help` works (extension installed)
- [x] `gh-stack` skill appears in Claude Code's skill list; `ralph`/`brief` correctly stay absent on work machine