### PR TITLE
Enable SSH connection multiplexing for main server

### DIFF
--- a/nix/modules/home/ssh.nix
+++ b/nix/modules/home/ssh.nix
@@ -94,6 +94,14 @@ in
           User = "root";
           Port = 8822;
           IdentityFile = "~/.ssh/${mainServerKeyFile}";
+          # Multiplexing: later sessions reuse the first connection's handshake.
+          # Persist is kept short so a master left dead by sleep or a LAN/Tailscale
+          # switch expires quickly instead of hanging new sessions;
+          # ServerAliveInterval makes a stale master notice and drop itself.
+          ControlMaster = "auto";
+          ControlPath = "~/.ssh/cm-%C"; # %C = hash — keeps it under the 104-char socket limit
+          ControlPersist = "1m";
+          ServerAliveInterval = 15;
         };
       } // (if mainServerName != nvmServerName then {
         "${nvmServerName}" = {


### PR DESCRIPTION
## Summary

Adds `ControlMaster`/`ControlPath`/`ControlPersist` to the main server block in `ssh.nix` so repeated `ssh` invocations reuse one connection instead of paying for a full TCP connect + key exchange + agent signature each time.

## Details

- `ControlPath` uses `%C` (hash) to stay under the 104-char unix socket path limit.
- `ControlPersist = "1m"` rather than a longer value: it still collapses the handshakes of a burst of `ssh` calls, while shrinking the window in which a dead master (laptop sleep, LAN <-> Tailscale switch) can leave new sessions hanging on a TCP timeout.
- `ServerAliveInterval = 15` makes a stale master notice and drop itself instead of hanging the next session.
- Scoped to the main server only; other hosts don't see repeated back-to-back connections.

## Test plan

- `nx lint` passes (flake eval + statix + deadnix)
- `nx up -hm` applied; rendered `~/.ssh/config` contains the expected directives
- Measured live: fresh `ssh leviathan true` 0.230s, multiplexed 0.013s; `ssh -O check` reports the master running