### PR TITLE
Disconnect unused MCP servers on work machine

### DIFF
--- a/nix/modules/home/claude.nix
+++ b/nix/modules/home/claude.nix
@@ -340,6 +340,33 @@ let
   ];
   # Snowflake (agentic — always ask)
   snowflakeAiMcpAskTools = [ "mcp__claude_ai_Snowflake__data-doula-agent" ];
+  # --- MCP servers to keep disconnected (context bloat / unused connectors) ---
+  deniedMcpServerNames = [
+    "claude.ai Ahrefs"
+    "claude.ai Airtable"
+    "claude.ai Amplitude"
+    "claude.ai Asana"
+    "claude.ai Atlassian"
+    "claude.ai BrightHire"
+    "claude.ai Canva"
+    "claude.ai Cloudinary"
+    "claude.ai Docusign"
+    "claude.ai Euno"
+    "claude.ai Figma"
+    "claude.ai Fireflies"
+    "claude.ai GeMCP"
+    "claude.ai Hex"
+    "claude.ai Miro"
+    "claude.ai Netsuite DEV"
+    "claude.ai Netsuite PROD"
+    "claude.ai Netsuite UAT"
+    "claude.ai Reclaim.ai"
+    "claude.ai Strella"
+    "claude.ai Vercel"
+    "claude.ai Zapier"
+    "claude.ai monday.com"
+    "plugin:datadog:datadog"
+  ];
 
   hooksDir = "${homeDirectory}/.claude/hooks";
 in
@@ -611,6 +638,9 @@ in
           };
         };
       };
+      deniedMcpServers = lib.optionals isWorkMachine (
+        map (name: { serverName = name; }) deniedMcpServerNames
+      );
       autoDreamEnabled = true;
       autoUpdates = true;
       teammateMode = "auto";


### PR DESCRIPTION
## Summary

Adds a `deniedMcpServers` entry to the Claude Code settings in `claude.nix` so unused claude.ai connectors and the Datadog plugin server stay disconnected. These servers load tool schemas into every session without being used, so keeping them denied cuts context bloat.

Gated behind `isWorkMachine` — the list is empty on the personal machine.

## Denied servers

Ahrefs, Airtable, Amplitude, Asana, Atlassian, BrightHire, Canva, Cloudinary, Docusign, Euno, Figma, Fireflies, GeMCP, Hex, Miro, Netsuite (DEV/PROD/UAT), Reclaim.ai, Strella, Vercel, Zapier, monday.com, and `plugin:datadog:datadog`.

## Test plan

- [ ] `nx check`
- [ ] `nx diff`
- [ ] `nx up -hm` and confirm the denied servers no longer connect