### PR TITLE
chore: bump mysql brew formula to 8.4

### DIFF
--- a/nix/modules/system/homebrew.nix
+++ b/nix/modules/system/homebrew.nix
@@ -12,7 +12,7 @@ let
     "just"
     "livekit-cli"
     "memcached"
-    "mysql@8.0"
+    "mysql@8.4"
     "pipenv"
     "pre-commit"
     "pyenv"


### PR DESCRIPTION
## Summary

Switches the Homebrew formula in `homebrew.nix` from `mysql@8.0` to `mysql@8.4`.

MySQL 8.0 has reached end of life, so this moves to the 8.4 LTS release.

## Test plan

- [ ] `nx check`
- [ ] `nx diff`
- [ ] `nx up`